### PR TITLE
Admin, Base: Use global LANGUAGES variable

### DIFF
--- a/modules/base/admin/module.py
+++ b/modules/base/admin/module.py
@@ -7,6 +7,7 @@ from discord.ext import commands, tasks
 
 import database.config
 from core import check, i18n, text, logging, utils
+from core import LANGUAGES as I18N_LANGUAGES
 from .database import BaseAdminModule as Module
 from .objects import RepositoryManager, Repository
 
@@ -15,6 +16,8 @@ tr = text.Translator(__file__).translate
 bot_log = logging.Bot.logger()
 guild_log = logging.Guild.logger()
 config = database.config.Config.get()
+
+LANGUAGES = ("en",) + I18N_LANGUAGES
 
 manager = RepositoryManager()
 
@@ -346,8 +349,7 @@ class Admin(commands.Cog):
             if bool_value is None:
                 return await ctx.send(_(ctx, "Invalid value"))
 
-        languages = ("en", "cs")
-        if key == "language" and value not in languages:
+        if key == "language" and value not in LANGUAGES:
             return await ctx.send(_(ctx, "Unsupported language"))
         genders = ("m", "f")
         if key == "gender" and value not in genders:

--- a/modules/base/language/module.py
+++ b/modules/base/language/module.py
@@ -2,6 +2,7 @@ from discord.ext import commands
 
 import database.config
 from core import check, text, logging, utils, i18n
+from core import LANGUAGES as I18N_LANGUAGES
 from database.language import GuildLanguage, MemberLanguage
 
 _ = i18n.Translator(__file__).translate
@@ -9,10 +10,7 @@ tr = text.Translator(__file__).translate
 guild_log = logging.Guild.logger()
 config = database.config.Config.get()
 
-# TODO Should it be here, or can we place it somewhere else
-# so that we don't have to hardcode the values on multiple places?
-# The only other input is in Admin cog, so it's not too bad.
-LANGUAGES = ("en", "cs")
+LANGUAGES = ("en",) + I18N_LANGUAGES
 
 
 class Language(commands.Cog):


### PR DESCRIPTION
Until now the supported languages were hardcoded on serveral places. Now
the bot will use the LANGUAGES variable specified in the core package.

Because the default is English, 'en' is not specified in that tuple.
Because of that, the functions that allow users to pick an interaction
language have to add the 'en' option where applicable.