### PR TITLE
Base: Allow userpin/userthread/bookmarks on replies

### DIFF
--- a/modules/base/base/module.py
+++ b/modules/base/base/module.py
@@ -463,7 +463,7 @@ class Base(commands.Cog):
             return
 
         # do not allow the actions on system messages (boost announcements etc.)
-        if message.type != discord.MessageType.default:
+        if message.type not in (discord.MessageType.default, discord.MessageType.reply):
             return
 
         if emoji == "📌" or emoji == "📍":


### PR DESCRIPTION
The message type filter did not take account that replies do not have
regular message type, but their own. This commit fixes that.