### PR TITLE
Fix "'staticmethod' object is not callable"

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -322,7 +322,6 @@ class ScrollableEmbed:
         await message.add_reaction("▶️")
         while True:
 
-            @staticmethod
             def check(reaction, user):
                 return (
                     reaction.message.id == message.id


### PR DESCRIPTION
If you create paginated embed, it causes error "'staticmethod' object is not callable".
