### PR TITLE
Fixed translation

### DIFF
--- a/core/help.py
+++ b/core/help.py
@@ -34,7 +34,7 @@ class Help(commands.MinimalHelpCommand):
 
         This override changes the language from english to l10n version.
         """
-        return _(ctx, "I don't know the **{name}** command".format(name=string))
+        return _(ctx, "I don't know the **{name}** command").format(name=string)
 
     def subcommand_not_found(self, command: commands.Command, string: str) -> str:
         ctx = self.context

--- a/modules/base/acl/module.py
+++ b/modules/base/acl/module.py
@@ -112,7 +112,7 @@ class ACL(commands.Cog):
         RE_NAME = r"[a-zA-Z-]+"
         if re.fullmatch(RE_NAME, name) is None:
             await ctx.reply(
-                _(ctx, "Bad group name (regex `{regex}`)".format(regex=RE_NAME))
+                _(ctx, "Bad group name (regex `{regex}`)").format(regex=RE_NAME)
             )
             return
 

--- a/modules/base/admin/module.py
+++ b/modules/base/admin/module.py
@@ -149,11 +149,8 @@ class Admin(commands.Cog):
         if repository.name in [r.name for r in manager.repositories]:
             tempdir.cleanup()
             await ctx.send(
-                _(
-                    ctx,
-                    "Repository named `{name}` already exists.".format(
-                        name=repository.name
-                    ),
+                _(ctx, "Repository named `{name}` already exists.").format(
+                    name=repository.name,
                 )
             )
             return

--- a/modules/base/base/module.py
+++ b/modules/base/base/module.py
@@ -30,7 +30,7 @@ class Base(commands.Cog):
     async def ping(self, ctx):
         """Return latency information."""
         delay: str = "{:.2f}".format(self.bot.latency)
-        await ctx.reply(_(ctx, "Pong: **{delay}** 🏓".format(delay=delay)))
+        await ctx.reply(_(ctx, "Pong: **{delay}** 🏓").format(delay=delay))
 
     @commands.command()
     async def uptime(self, ctx):

--- a/modules/base/errors/module.py
+++ b/modules/base/errors/module.py
@@ -109,11 +109,8 @@ class Errors(commands.Cog):
         if type(error) == commands.MissingRequiredArgument:
             return (
                 _(ctx, "Command error"),
-                _(
-                    ctx,
-                    "The command has to have an argument `{arg}`".format(
-                        arg=error.param.name
-                    ),
+                _(ctx, "The command has to have an argument `{arg}`").format(
+                    arg=error.param.name,
                 ),
                 False,
             )


### PR DESCRIPTION
Fixed replacing arguments before translation.

Example:

```Python
_(ctx, "Text {replace}".format(replace=replace))```