### PR TITLE
Reworked ScrollableEmbed

### DIFF
--- a/core/po/cs.popie
+++ b/core/po/cs.popie
@@ -12,3 +12,6 @@ msgstr Příkaz **{name}** nemá žádný podpříkaz
 
 msgid Page
 msgstr Strana
+
+msgid No results were found.
+msgstr Nebyl nalezen žádný výsledek

--- a/core/po/sk.popie
+++ b/core/po/sk.popie
@@ -12,3 +12,6 @@ msgstr
 
 msgid Page
 msgstr
+
+msgid No results were found.
+msgstr

--- a/core/utils.py
+++ b/core/utils.py
@@ -364,7 +364,8 @@ class ScrollableEmbed:
                     "reaction_add", check=check, timeout=300.0
                 )
             except asyncio.TimeoutError:
-                await message.clear_reactions()
+                with contextlib.suppress(discord.NotFound, discord.Forbidden):
+                    await message.clear_reactions()
                 break
             else:
                 if str(reaction.emoji) == "◀️":

--- a/core/utils.py
+++ b/core/utils.py
@@ -302,13 +302,6 @@ class ScrollableEmbed:
     def __init__(
         self, ctx: commands.Context, iterable: Iterable[discord.Embed]
     ) -> ScrollableEmbed:
-        """[summary]
-
-
-
-        Returns:
-            ScrollableEmbed: [description]
-        """
         self.pages = self._pages_from_iter(ctx, iterable)
         self.ctx = ctx
 

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import datetime
 import contextlib
@@ -290,8 +292,25 @@ class Discord:
 
 
 class ScrollableEmbed:
-    def __init__(self):
-        self.pages = []
+    """Class for making scrollable embeds easy.
+
+    Args:
+        ctx (:class:`discord.ext.commands.Context`): The context for translational purposes.
+        iterable (:class:`Iterable[discord.Embed]`): Iterable which to build the ScrollableEmbed from.
+    """
+
+    def __init__(
+        self, ctx: commands.Context, iterable: Iterable[discord.Embed]
+    ) -> ScrollableEmbed:
+        """[summary]
+
+
+
+        Returns:
+            ScrollableEmbed: [description]
+        """
+        self.pages = self._pages_from_iter(ctx, iterable)
+        self.ctx = ctx
 
     def __repr__(self):
         return (
@@ -299,9 +318,10 @@ class ScrollableEmbed:
             f"page_count='{len(self.pages)}' pages='[{self.pages}]'>"
         )
 
-    def from_iter(
-        self, ctx: discord.ext.commands.Context, iterable: Iterable[discord.Embed]
-    ):
+    def _pages_from_iter(
+        self, ctx: commands.Context, iterable: Iterable[discord.Embed]
+    ) -> list[discord.Embed]:
+        pages = []
         for idx, embed in enumerate(iterable):
             if type(embed) is not discord.Embed:
                 raise ValueError("Items in iterable must be of type discord.Embed")
@@ -310,14 +330,24 @@ class ScrollableEmbed:
                 value="{curr}/{total}".format(curr=idx + 1, total=len(iterable)),
                 inline=False,
             )
-            self.pages.append(embed)
+            pages.append(embed)
+        return pages
 
-    async def scroll(self, ctx: discord.ext.commands.Context):
+    async def scroll(self):
+        """Make them embeds move.
+
+        Sends the first page to the context and handles scrolling.
+        """
+        ctx = self.ctx
         if self.pages == []:
-            raise IndexError("Cannot scroll empty page list")
+            await ctx.reply(_(ctx, "No results were found."))
+            return
 
         message = await ctx.send(embed=self.pages[0])
         pagenum = 0
+        if len(self.pages) == 1:
+            return
+
         await message.add_reaction("◀️")
         await message.add_reaction("▶️")
         while True:


### PR DESCRIPTION
Simpler usage, handles empty lists, handles lists of length 1

Usage:
```py
scrollable_embed = utils.ScrollableEmbed(ctx, embeds)
await scrollable_embed.scroll()
```