### PR TITLE
Core: Fix language of ScrollableEmbed replies

### DIFF
--- a/pie/i18n/__init__.py
+++ b/pie/i18n/__init__.py
@@ -24,7 +24,7 @@ class TranslationContext:
 
     __slots__ = ("guild_id", "user_id")
 
-    def __init__(self, guild_id: int, user_id: int):
+    def __init__(self, guild_id: Optional[int], user_id: Optional[int]):
         self.guild_id = guild_id
         self.user_id = user_id
 

--- a/pie/po/cs.popie
+++ b/pie/po/cs.popie
@@ -17,7 +17,7 @@ msgid No results were found.
 msgstr Nebyl nalezen žádný výsledek
 
 msgid Only command issuer can scroll.
-msgstr Pouze odesilatel příkazu může posouvat stránky.
+msgstr Pouze odesílatel příkazu může posouvat stránky.
 
 msgid Confirm
 msgstr Potvrdit

--- a/pie/utils/objects.py
+++ b/pie/utils/objects.py
@@ -92,8 +92,14 @@ class ScrollableEmbed(nextcord.ui.View):
     async def interaction_check(self, interaction: nextcord.Interaction) -> None:
         """Gets called when interaction with any of the Views buttons happens."""
         if interaction.user.id is not self.ctx.author.id:
+            if self.ctx.guild is not None:
+                gtx = i18n.TranslationContext(self.ctx.guild.id, interaction.user.id)
+            else:
+                # TranslationContext does not know how to use user without guild,
+                # this will result in bot preference being used.
+                gtx = i18n.TranslationContext(None, interaction.user.id)
             await interaction.response.send_message(
-                _(self.ctx, "Only command issuer can scroll."), ephemeral=True
+                _(gtx, "Only command issuer can scroll."), ephemeral=True
             )
             return
 


### PR DESCRIPTION
Previously, the language preference of the issuer was used. Now we will
be using language of the user that clicked on interaction.

Additional changes:
- Fix one related czech string.
- Make TranslationContext init arguments optional.

Resolves #197