### PR TITLE
Admin: Send a warning about database on repository install

### DIFF
--- a/modules/base/admin/module.py
+++ b/modules/base/admin/module.py
@@ -164,6 +164,13 @@ class Admin(commands.Cog):
                 for output in utils.text.split(install):
                     await ctx.send("```" + output + "```")
 
+        # check if the repository uses database
+        has_database: bool = False
+        for module in repository.module_names:
+            if (repository.path / module / "database.py").is_file():
+                has_database = True
+                break
+
         # move to modules/
         repository_location = str(Path.cwd() / "modules" / repository.name)
         shutil.move(str(workdir), repository_location)
@@ -183,6 +190,16 @@ class Admin(commands.Cog):
             ctx.channel,
             f"Repository {repository.name} installed.",
         )
+
+        if has_database:
+            await ctx.send(
+                _(
+                    ctx,
+                    "Repository contains at least one database file. "
+                    "Make sure you restart the bot before you load the modules "
+                    "to ensure database tables were created.",
+                ),
+            )
 
     @commands.max_concurrency(1, per=commands.BucketType.default, wait=False)
     @commands.check(check.acl)

--- a/modules/base/po/cs.popie
+++ b/modules/base/po/cs.popie
@@ -94,6 +94,9 @@ msgstr Repozitář pojmenovaný `{name}` už existuje.
 msgid Repository has been installed to `{path}`. It includes the following modules: {modules}.
 msgstr Repozitář byl nainstalován do `{path}`. Obsahuje následující moduly: {modules}.
 
+msgid Repository contains at least one database file. Make sure you restart the bot before you load the modules to ensure database tables were created.
+msgstr Repozitář obsahuje alespoň jeden soubor databáze. Před načtením modulů proveďte restart bota, aby byly všechny tabulky databáze aktualizovány.
+
 msgid No such repository.
 msgstr Takový repozitář neexistuje.
 

--- a/modules/base/po/sk.popie
+++ b/modules/base/po/sk.popie
@@ -94,6 +94,9 @@ msgstr Repozitár pomenovaný `{name}` už existuje.
 msgid Repository has been installed to `{path}`. It includes the following modules: {modules}.
 msgstr Repozitár bol nainštalovaný do `{path}`. Obsahuje následujúce moduly: {modules}.
 
+msgid Repository contains at least one database file. Make sure you restart the bot before you load the modules to ensure database tables were created.
+msgstr Repozitár obsahuje aspoň jeden súbor databáze. Pred načítaním modulov vykonajte reštart bota, aby boli všetky tabuľky databáze aktualizované.
+
 msgid No such repository.
 msgstr Takýto repozitár neexistuje.
 


### PR DESCRIPTION
When a repo which uses database is cloned, no table is created
automatically. Now the bot will send a note that restart is required.

Resolves #191