### PR TITLE
Reworked errors

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,9 @@ services:
       - POSTGRES_EXTRA_OPTS=-Z9 --schema=public --blobs
       - SCHEDULE=@every 3h00m00s
   bot:
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile
     env_file: .env
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"

--- a/modules/base/errors/module.py
+++ b/modules/base/errors/module.py
@@ -21,6 +21,8 @@ guild_log = logger.Guild.logger()
 # TODO This is just a weird list of errors. Maybe we should make it somehow
 # simpler, e.g. split the "get translation" from "should we log this?".
 
+IGNORED_EXCEPTIONS = [commands.CommandNotFound]
+
 
 class Errors(commands.Cog):
     """Error handling module."""
@@ -49,16 +51,648 @@ class Errors(commands.Cog):
                 break
             error = new_error
 
-        # Prevent some exceptions from being reported
-        if type(error) == commands.CommandNotFound:
+        if type(error) in IGNORED_EXCEPTIONS:
             return
 
-        # Get information
-        title, content, log_error = Errors.__get_error_message(ctx, error)
+        # Exception handling
+        title, content, ignore_traceback = await Errors.handle_exceptions(ctx, error)
+
+        # Exception logging
+        await Errors.handle_log(
+            ctx,
+            error,
+            title=title,
+            content=content,
+            ignore_traceback=ignore_traceback,
+        )
+
+    @staticmethod
+    async def handle_exceptions(ctx, error) -> Tuple[str, str, bool]:
+        """Handles creating embed titles and descriptions of various exceptions
+
+        Args:
+            ctx: The invocation context.
+            error: Detected exception.
+
+        Returns:
+            Tuple[str, str, bool]: Translated error name, Translated description, Whether to ignore traceback in the log
+        """
+        # pumpkin.py own exceptions
+        if isinstance(error, pie.exceptions.PumpkinException):
+            return await Errors.handle_PumpkinException(ctx, error)
+        # Discord errors
+        elif isinstance(error, nextcord.DiscordException):
+            return await Errors.handle_DiscordException(ctx, error)
+        # Other errors
+        else:
+            return (
+                type(error).__name__,
+                _(ctx, "An unexpected error occurred"),
+                False,
+            )
+
+    @staticmethod
+    async def handle_PumpkinException(ctx, error) -> Tuple[str, str, bool]:
+        """Handles exceptions raised by pumpkin-py
+
+        Args:
+            ctx: The invocation context.
+            error: Detected exception.
+
+        Returns:
+            Tuple[str, str, bool]: Translated error name, Translated description, Whether to ignore traceback in the log
+        """
+        error_messages = {
+            "PumpkinException": _(ctx, "pumpkin.py exception"),
+            "DotEnvException": _(ctx, "An environment variable is missing"),
+            "ModuleException": _(ctx, "Module exception"),
+            "BadTranslation": _(ctx, "Translation error"),
+        }
+        title = error_messages.get(
+            type(error).__name__,
+            _(ctx, "An unexpected error occurred"),
+        )
+        return (title, str(error), False)
+
+    @staticmethod
+    async def handle_DiscordException(ctx, error) -> Tuple[str, str, bool]:
+        """Handles exceptions raised by Discord
+
+        Args:
+            ctx: The invocation context.
+            error: Detected exception.
+
+        Returns:
+            Tuple[str, str, bool]: Translated error name, Translated description, Whether to ignore traceback in the log
+        """
+        # Exception that's raised when an operation in the Client fails.
+        if isinstance(error, nextcord.ClientException):
+            return await Errors.handle_ClientException(ctx, error)
+        # Exception that is raised when an async iteration operation has no more items.
+        elif isinstance(error, nextcord.NoMoreItems):
+            # FIXME: What exactly ist this?
+            return (
+                _(ctx, "Error"),
+                _(ctx, "pumpkin.py exception"),
+                False,
+            )
+        # An exception that is raised when the gateway for Discord could not be found.
+        elif isinstance(error, nextcord.GatewayNotFound):
+            return (
+                _(ctx, "Error"),
+                _(ctx, "Gateway not found"),
+                False,
+            )
+        # Exception that's raised when an HTTP request operation fails.
+        elif isinstance(error, nextcord.HTTPException):
+            return await Errors.handle_HTTPException(ctx, error)
+        # The base exception type for all command related errors.
+        elif isinstance(error, commands.CommandError):
+            return await Errors.handle_CommandError(ctx, error)
+        # Base exception for extension related errors.
+        elif isinstance(error, commands.ExtensionError):
+            return await Errors.handle_ExtensionError(ctx, error)
+        # Just in case we missed something
+        else:
+            return (
+                _(ctx, "Error"),
+                _(ctx, "Nextcord library error"),
+                False,
+            )
+
+    @staticmethod
+    async def handle_ClientException(ctx, error) -> Tuple[str, str, bool]:
+        """Handles exceptions raised by the Client
+
+        Args:
+            ctx: The invocation context.
+            error: Detected exception.
+
+        Returns:
+            Tuple[str, str, bool]: Translated error name, Translated description, Whether to ignore traceback in the log
+        """
+        # FIXME: We have all these nice exceptions and yet we don't handle them. Is it intentional?
+        # I at least prepared this if-elif-else block if that is to change
+
+        # Exception that's raised when the library encounters unknown or invalid data from Discord.
+        if isinstance(error, nextcord.InvalidData):
+            return (
+                _(ctx, "Client error"),
+                _(ctx, "Invalid data"),
+                False,
+            )
+        # Exception that's raised when an argument to a function is invalid some way (e.g. wrong value or wrong type).
+        # This could be considered the analogous of ValueError and TypeError except inherited from ClientException and thus DiscordException.
+        elif isinstance(error, nextcord.InvalidArgument):
+            return (
+                _(ctx, "Client error"),
+                _(ctx, "Invalid argument"),
+                False,
+            )
+        # Exception that's raised when the Client.login function fails to log you in from improper credentials or some other misc. failure.
+        elif isinstance(error, nextcord.LoginFailure):
+            return (
+                _(ctx, "Client error"),
+                _(ctx, "Login failure"),
+                False,
+            )
+        # Exception that's raised when the gateway connection is closed for reasons that could not be handled internally.
+        elif isinstance(error, nextcord.ConnectionClosed):
+            return (
+                _(ctx, "Client error"),
+                _(ctx, "Connection closed"),
+                False,
+            )
+        # Exception that's raised when the gateway is requesting privileged intents but they're not ticked in the developer page yet.
+        elif isinstance(error, nextcord.PrivilegedIntentsRequired):
+            return (
+                _(ctx, "Client error"),
+                _(ctx, "Privileged intents required"),
+                False,
+            )
+        # An exception raised when the command can't be added because the name is already taken by a different command.
+        elif isinstance(error, commands.CommandRegistrationError):
+            return (
+                _(ctx, "Client error"),
+                _(ctx, "Error on registering the command `{cmd}`").format(
+                    cmd=error.name
+                ),
+                True,
+            )
+        # Just in case we missed something
+        else:
+            return (
+                _(ctx, "Error"),
+                _(ctx, "Client error"),
+                False,
+            )
+
+    @staticmethod
+    async def handle_HTTPException(ctx, error) -> Tuple[str, str, bool]:
+        """Handles exceptions raised by the HTTP connection to the Discord API.
+
+        Args:
+            ctx: The invocation context.
+            error: Detected exception.
+
+        Returns:
+            Tuple[str, str, bool]: Translated error name, Translated description, Whether to ignore traceback in the log
+        """
+        # Exception that's raised for when status code 403 occurs.
+        if isinstance(error, nextcord.Forbidden):
+            return (
+                _(ctx, "HTTP Exception"),
+                _(ctx, "Forbidden"),
+                True,
+            )
+        # Exception that's raised for when status code 404 occurs.
+        elif isinstance(error, nextcord.NotFound):
+            return (
+                _(ctx, "HTTP Exception"),
+                _(ctx, "NotFound"),
+                True,
+            )
+        # Exception that's raised for when a 500 range status code occurs.
+        elif isinstance(error, nextcord.DiscordServerError):
+            return (
+                _(ctx, "HTTP Exception"),
+                _(ctx, "Discord Server Error"),
+                True,
+            )
+        # Just in case we missed something
+        else:
+            return (
+                _(ctx, "Nextcord library error"),
+                _(ctx, "HTTP Exception"),
+                False,
+            )
+
+    @staticmethod
+    async def handle_ExtensionError(ctx, error) -> Tuple[str, str, bool]:
+        """Handles exceptions raised by pumpkin-py extensions
+
+        Args:
+            ctx: The invocation context.
+            error: Detected exception.
+
+        Returns:
+            Tuple[str, str, bool]: Translated error name, Translated description, Whether to ignore traceback in the log
+        """
+        # return friendly name, e.g. strip "modules.{module}.module"
+        name = error.name[8:-7]
+        # send helpful message if the requested module does not follow naming rules
+        if re.fullmatch(r"([a-z_]+)\.([a-z_]+)", name) is None:
+            description = _(
+                ctx,
+                "The extension **{extension}** could not be found. It should be in `repository.module` format",
+            ).format(
+                extension=name,
+            )
+        # An exception raised when an extension has already been loaded.
+        elif isinstance(error, commands.ExtensionAlreadyLoaded):
+            description = _(ctx, "Extension **{extension}** is already loaded").format(
+                extension=name,
+            )
+        # An exception raised when an extension was not loaded.
+        elif isinstance(error, commands.ExtensionNotLoaded):
+            description = _(ctx, "The extension **{extension}** is not loaded").format(
+                extension=name,
+            )
+        # An exception raised when an extension does not have a setup entry point function.
+        elif isinstance(error, commands.NoEntryPointError):
+            description = _(
+                ctx, "Extension **{extension}** doesn't have a setup entry function"
+            ).format(
+                extension=name,
+            )
+        # An exception raised when an extension failed to load during execution of the module or setup entry point.
+        elif isinstance(error, commands.ExtensionFailed):
+            description = _(ctx, "**{extension}** failed").format(extension=name)
+        # An exception raised when an extension is not found.
+        elif isinstance(error, commands.ExtensionNotFound):
+            description = _(
+                ctx, "The extension **{extension}** could not be found"
+            ).format(
+                extension=name,
+            )
+        # Just in case we missed something
+        else:
+            return (
+                _(ctx, "Nextcord library error"),
+                _(ctx, "Extension error"),
+                False,
+            )
+        return (
+            _(ctx, "Extension Error"),
+            description + ":\n" + str(error),
+            False,
+        )
+
+    @staticmethod
+    async def handle_CommandError(ctx, error) -> Tuple[str, str, bool]:
+        """Handles exceptions raised by pumpkin-py commands
+
+        Args:
+            ctx: The invocation context.
+            error: Detected exception.
+
+        Returns:
+            Tuple[str, str, bool]: Translated error name, Translated description, Whether to ignore traceback in the log
+        """
+
+        # Exception raised when a Converter class raises non-CommandError.
+        if isinstance(error, commands.ConversionError):
+            return (
+                _(ctx, "Command error"),
+                _(ctx, "An error occurred in converter `{converter}`").format(
+                    converter=type(error.converter).__name__,
+                ),
+                False,
+            )
+        # The base exception type for errors that involve errors regarding user input.
+        elif isinstance(error, commands.UserInputError):
+            return await Errors.handle_UserInputError(ctx, error)
+        # Exception raised when a command is attempted to be invoked but no command under that name is found.
+        elif isinstance(error, commands.CommandNotFound):
+            return (
+                _(ctx, "Command error"),
+                _(ctx, "Command not found"),
+                True,
+            )
+        # Exception raised when the predicates in .Command.checks have failed.
+        elif isinstance(error, commands.CheckFailure):
+            return await Errors.handle_CheckFailure(ctx, error)
+        # Exception raised when the command being invoked is disabled.
+        elif isinstance(error, commands.DisabledCommand):
+            return (
+                _(ctx, "Command error"),
+                _(ctx, "Disabled command"),
+                True,
+            )
+        # Exception raised when the command being invoked raised an exception.
+        elif isinstance(error, commands.CommandInvokeError):
+            return (
+                _(ctx, "Command error"),
+                _(ctx, "Command invoke error"),
+                False,
+            )
+        # Exception raised when the command being invoked is on cooldown.
+        elif isinstance(error, commands.CommandOnCooldown):
+            time = utils.time.format_seconds(error.retry_after)
+            return (
+                _(ctx, "Command error"),
+                _(ctx, "Slow down. Wait **{time}**").format(time=time),
+                True,
+            )
+        # Exception raised when the command being invoked has reached its maximum concurrency.
+        elif isinstance(error, commands.MaxConcurrencyReached):
+            return (
+                _(ctx, "Command error"),
+                _(ctx, "This command is already running multiple times")
+                + "\n"
+                + _(ctx, "The limit is **{num}**/**{per}**").format(
+                    num=error.number,
+                    per=error.per.name,
+                ),
+                True,
+            )
+        # Just in case we missed something
+        else:
+            return (
+                _(ctx, "Nextcord library error"),
+                _(ctx, "Command error"),
+                False,
+            )
+
+    @staticmethod
+    async def handle_CheckFailure(ctx, error) -> Tuple[str, str, bool]:
+        """Handles exceptions raised by command checks.
+
+        Args:
+            ctx: The invocation context.
+            error: Detected exception.
+
+        Returns:
+            Tuple[str, str, bool]: Translated error name, Translated description, Whether to ignore traceback in the log
+        """
+        # Exception raised when all predicates in check_any fail.
+        if isinstance(error, commands.CheckAnyFailure):
+            return (
+                _(ctx, "Check failure"),
+                _(
+                    ctx,
+                    "You do not have any of the possible permissions to access this command",
+                ),
+                True,
+            )
+        # Exception raised when an operation does not work outside of private message contexts.
+        elif isinstance(error, commands.PrivateMessageOnly):
+            return (
+                _(ctx, "Check failure"),
+                _(ctx, "This command can only be used in private messages."),
+                True,
+            )
+        # Exception raised when an operation does not work in private message contexts.
+        elif isinstance(error, commands.NoPrivateMessage):
+            return (
+                _(ctx, "Check failure"),
+                _(ctx, "This command cannot be used in private messages."),
+                True,
+            )
+        # Exception raised when the message author is not the owner of the bot.
+        elif isinstance(error, commands.NotOwner):
+            return (
+                _(ctx, "Check failure"),
+                _(ctx, "You are not the bot owner"),
+                True,
+            )
+        # Exception raised when the command invoker lacks permissions to run a command.
+        elif isinstance(error, commands.MissingPermissions):
+            perms = ", ".join(f"**{p}**" for p in error.missing_perms)
+            return (
+                _(ctx, "Check failure"),
+                _(ctx, "You lack some of {perms} permissions").format(perms=perms),
+                True,
+            )
+        # Exception raised when the bot's member lacks permissions to run a command.
+        elif isinstance(error, commands.BotMissingPermissions):
+            perms = ", ".join(f"`{p}`" for p in error.missing_perms)
+            return (
+                _(ctx, "Check failure"),
+                _(ctx, "I lack the {perms} permission").format(perms=perms),
+                True,
+            )
+        # Exception raised when the command invoker lacks a role to run a command.
+        elif isinstance(error, commands.MissingRole):
+            return (
+                _(ctx, "Check failure"),
+                _(ctx, "You have to have a {role} role for that").format(
+                    role=f"`{error.missing_role!r}`",
+                ),
+                True,
+            )
+        # Exception raised when the bot's member lacks a role to run a command.
+        elif isinstance(error, commands.BotMissingRole):
+            return (
+                _(ctx, "Check failure"),
+                _(ctx, "I lack the role {role}").format(
+                    role=f"`{error.missing_role!r}`"
+                ),
+                True,
+            )
+        # Exception raised when the command invoker lacks any of the roles specified to run a command.
+        elif isinstance(error, commands.MissingAnyRole):
+            roles = ", ".join(f"**{r!r}**" for r in error.missing_roles)
+            return (
+                _(ctx, "Check failure"),
+                _(ctx, "You have to have one role of {roles}").format(roles=roles),
+                True,
+            )
+        # Exception raised when the bot's member lacks any of the roles specified to run a command.
+        elif isinstance(error, commands.BotMissingAnyRole):
+            roles = ", ".join(f"**{r!r}**" for r in error.missing_roles)
+            return (
+                _(ctx, "Check failure"),
+                _(ctx, "I need one of roles {roles}").format(roles=roles),
+                True,
+            )
+        # Exception raised when a channel does not have the required NSFW setting.
+        elif isinstance(error, commands.NSFWChannelRequired):
+            return (
+                _(ctx, "Check failure"),
+                _(ctx, "This command can be used only in NSFW channels."),
+                True,
+            )
+        # Just in case we missed something
+        else:
+            return (
+                _(ctx, "Nextcord library error"),
+                _(ctx, "Check failure"),
+                False,
+            )
+
+    @staticmethod
+    async def handle_UserInputError(ctx, error) -> Tuple[str, str, bool]:
+        """Handles exceptions raised by user input.
+
+        Args:
+            ctx: The invocation context.
+            error: Detected exception.
+
+        Returns:
+            Tuple[str, str, bool]: Translated error name, Translated description, Whether to ignore traceback in the log
+        """
+        # Exception raised when parsing a command and a parameter that is required is not encountered.
+        if isinstance(error, commands.MissingRequiredArgument):
+            return (
+                _(ctx, "User input error"),
+                _(ctx, "The command has to have an argument `{arg}`").format(
+                    arg=error.param.name,
+                ),
+                True,
+            )
+        # Exception raised when the command was passed too many arguments and its .Command.ignore_extra attribute was not set to True.
+        elif isinstance(error, commands.TooManyArguments):
+            return (
+                _(ctx, "User input error"),
+                _(ctx, "The command doesn't have that many arguments."),
+                True,
+            )
+        # Exception raised when a parsing or conversion failure is encountered on an argument to pass into a command.
+        elif isinstance(error, commands.BadArgument):
+            # Exception raised when the message provided was not found in the channel.
+            if isinstance(error, commands.MessageNotFound):
+                return (
+                    _(ctx, "Bad argument"),
+                    _(ctx, "Message not found"),
+                    True,
+                )
+            # Exception raised when the member provided was not found in the bot's cache.
+            elif isinstance(error, commands.MemberNotFound):
+                return (
+                    _(ctx, "Bad argument"),
+                    _(ctx, "Member not found"),
+                    True,
+                )
+            # Exception raised when the user provided was not found in the bot's cache.
+            elif isinstance(error, commands.UserNotFound):
+                return (
+                    _(ctx, "Bad argument"),
+                    _(ctx, "User not found"),
+                    True,
+                )
+            # Exception raised when the bot can not find the channel.
+            elif isinstance(error, commands.ChannelNotFound):
+                return (
+                    _(ctx, "Bad argument"),
+                    _(ctx, "Channel not found"),
+                    True,
+                )
+            # Exception raised when the bot does not have permission to read messages in the channel.
+            elif isinstance(error, commands.ChannelNotReadable):
+                return (
+                    _(ctx, "Bad argument"),
+                    _(ctx, "I can't see the **{channel}** channel").format(
+                        channel=error.argument.name,
+                    ),
+                    True,
+                )
+            # Exception raised when the colour is not valid.
+            elif isinstance(error, commands.BadColourArgument):
+                return (
+                    _(ctx, "Bad argument"),
+                    _(ctx, "Bad colour argument"),
+                    True,
+                )
+            # Exception raised when the bot can not find the role.
+            elif isinstance(error, commands.RoleNotFound):
+                return (
+                    _(ctx, "Bad argument"),
+                    _(ctx, "Role not found"),
+                    True,
+                )
+            # Exception raised when the invite is invalid or expired.
+            elif isinstance(error, commands.BadInviteArgument):
+                return (
+                    _(ctx, "Bad argument"),
+                    _(ctx, "Bad invite argument"),
+                    True,
+                )
+            # Exception raised when the bot can not find the emoji.
+            elif isinstance(error, commands.EmojiNotFound):
+                return (
+                    _(ctx, "Bad argument"),
+                    _(ctx, "Emoji not found"),
+                    True,
+                )
+            # Exception raised when the emoji provided does not match the correct format.
+            elif isinstance(error, commands.PartialEmojiConversionFailure):
+                return (
+                    _(ctx, "Bad argument"),
+                    _(ctx, "PartialEmoji conversion failure"),
+                    True,
+                )
+            # Exception raised when a boolean argument was not convertable.
+            elif isinstance(error, commands.BadBoolArgument):
+                return (
+                    _(ctx, "Bad argument"),
+                    _(ctx, "Bad bool argument"),
+                    True,
+                )
+            # Just in case we missed something
+            else:
+                return (
+                    _(ctx, "User input error"),
+                    _(ctx, "Bad argument"),
+                    True,
+                )
+        # Exception raised when a typing.Union converter fails for all its associated types.
+        elif isinstance(error, commands.BadUnionArgument):
+            return (
+                _(ctx, "User input error"),
+                _(ctx, "Bad Union argument"),
+                True,
+            )
+        # Exception raised when a parsing or conversion failure is encountered on an argument to pass into a command.
+        elif isinstance(error, commands.ArgumentParsingError):
+            # An exception raised when the parser encounters a quote mark inside a non-quoted string
+            if isinstance(error, commands.UnexpectedQuoteError):
+                return (
+                    _(ctx, "Argument parsing error"),
+                    _(ctx, "Unexpected quote error"),
+                    True,
+                )
+            # An exception raised when a space is expected after the closing quote in a string but a different character is found.
+            elif isinstance(error, commands.InvalidEndOfQuotedStringError):
+                return (
+                    _(ctx, "Argument parsing error"),
+                    _(ctx, "Invalid end of quoted string error"),
+                    True,
+                )
+            # An exception raised when a quote character is expected but not found.
+            elif isinstance(error, commands.ExpectedClosingQuoteError):
+                return (
+                    _(ctx, "Argument parsing error"),
+                    _(ctx, "Unexpected quote error"),
+                    True,
+                )
+            # Just in case we missed something
+            else:
+                return (
+                    _(ctx, "User input error"),
+                    _(ctx, "Argument parsing error"),
+                    False,
+                )
+        # Just in case we missed something
+        else:
+            return (
+                _(ctx, "Nextcord library error"),
+                _(ctx, "User input error"),
+                False,
+            )
+
+    @staticmethod
+    async def handle_log(
+        ctx,
+        error,
+        title: str,
+        content: str,
+        ignore_traceback: bool = False,
+    ):
+        """Handles the exception logging
+
+        Args:
+            ctx: The invocation context.
+            error: Detected exception.
+            title: Translated error name
+            content: Translated description
+            ignore_traceback: Whether to ignore traceback in the log. Defaults to False.
+        """
+
         embed = utils.discord.create_embed(
             author=ctx.author, error=True, title=title, description=content
         )
-        if log_error:
+        if not ignore_traceback:
             embed.add_field(
                 name=_(ctx, "Error content"),
                 value=str(error),
@@ -67,7 +701,7 @@ class Errors(commands.Cog):
         await ctx.send(embed=embed)
 
         # Log the error
-        if log_error:
+        if not ignore_traceback:
             await bot_log.error(
                 ctx.author,
                 ctx.channel,
@@ -75,282 +709,6 @@ class Errors(commands.Cog):
                 content=ctx.message.content,
                 exception=error,
             )
-
-    def __get_error_message(
-        ctx: commands.Context, error: Exception
-    ) -> Tuple[str, str, bool]:
-        """Get message for the error.
-
-        :param ctx: The invocation context.
-        :param error: Detected exception.
-        :return:
-            title (Translated error name),
-            content (Translated description),
-            write_tb (Whether to display traceback in the log),
-        """
-
-        # pumpkin.py own exceptions
-        if isinstance(error, pie.exceptions.PumpkinException):
-            error_message = {
-                "PumpkinException": _(ctx, "pumpkin.py exception"),
-                "DotEnvException": _(ctx, "An environment variable is missing"),
-                "ModuleException": _(ctx, "Module exception"),
-                "BadTranslation": _(ctx, "Translation error"),
-            }
-            return (
-                error_message.get(
-                    type(error).__name__, _(ctx, "An unexpected error occurred")
-                ),
-                str(error),
-                True,
-            )
-
-        # interactions
-        if type(error) == commands.MissingRequiredArgument:
-            return (
-                _(ctx, "Command error"),
-                _(ctx, "The command has to have an argument `{arg}`").format(
-                    arg=error.param.name,
-                ),
-                False,
-            )
-        if type(error) == commands.CheckFailure:
-            return (
-                _(ctx, "Permission error"),
-                _(ctx, "Insufficient permission"),
-                False,
-            )
-        if type(error) == commands.CommandOnCooldown:
-            time = utils.time.seconds(error.retry_after)
-            return (
-                _(ctx, "Slow down"),
-                _(ctx, "Wait **{time}**").format(time=time),
-                False,
-            )
-        if type(error) == commands.MaxConcurrencyReached:
-            return (
-                _(ctx, "Too much concurrency"),
-                _(ctx, "This command is already running multiple times")
-                + "\n"
-                + _(ctx, "The limit is **{num}**/**{per}**").format(
-                    num=error.number,
-                    per=error.per.name,
-                ),
-                False,
-            )
-        if type(error) == commands.MissingRole:
-            return (
-                _(ctx, "Permission error"),
-                _(ctx, "You have to have a {role} role for that").format(
-                    role=f"`{error.missing_role!r}`",
-                ),
-                False,
-            )
-        if type(error) == commands.BotMissingRole:
-            return (
-                _(ctx, "Permission error"),
-                _(ctx, "I lack the role {role}").format(
-                    role=f"`{error.missing_role!r}`"
-                ),
-                False,
-            )
-        if type(error) == commands.MissingAnyRole:
-            roles = ", ".join(f"**{r!r}**" for r in error.missing_roles)
-            return (
-                _(ctx, "Permission error"),
-                _(ctx, "You have to have one role of {roles}").format(roles=roles),
-                False,
-            )
-        if type(error) == commands.BotMissingAnyRole:
-            roles = ", ".join(f"**{r!r}**" for r in error.missing_roles)
-            return (
-                _(ctx, "Permission error"),
-                _(ctx, "I need one of roles {roles}").format(roles=roles),
-                False,
-            )
-        if type(error) == commands.MissingPermissions:
-            perms = ", ".join(f"**{p}**" for p in error.missing_perms)
-            return (
-                _(ctx, "Permission error"),
-                _(ctx, "You lack some of {perms} permissions").format(perms=perms),
-                False,
-            )
-        if type(error) == commands.BotMissingPermissions:
-            perms = ", ".join(f"`{p}`" for p in error.missing_perms)
-            return (
-                _(ctx, "Permission error"),
-                _(ctx, "I lack the {perms} permission").format(perms=perms),
-                False,
-            )
-        if type(error) == commands.BadUnionArgument:
-            return (
-                _(ctx, "Argument error"),
-                _(ctx, "Bad data type in the `{param}` parameter").format(
-                    param=error.param.name,
-                ),
-                False,
-            )
-        if type(error) == commands.BadBoolArgument:
-            return (
-                _(ctx, "Bad Boolean Argument"),
-                _(ctx, "Argument `{arg}` is not binary").format(arg=error.argument),
-                False,
-            )
-        if type(error) == commands.ConversionError:
-            return (
-                _(ctx, "Command error"),
-                _(ctx, "An error occurred in converter `{converter}`").format(
-                    converter=type(error.converter).__name__,
-                ),
-                False,
-            )
-        if type(error) == commands.ChannelNotReadable:
-            return (
-                _(ctx, "Not found"),
-                _(ctx, "I can't see the **{channel}** channel").format(
-                    channel=error.argument.name,
-                ),
-                False,
-            )
-        if isinstance(error, commands.BadArgument):
-            return (
-                _(ctx, "Bad Argument"),
-                _(ctx, "Error in argument"),
-                False,
-            )
-
-        if isinstance(error, commands.NoPrivateMessage):
-            return (
-                _(ctx, "No Private Message"),
-                _(ctx, "This command cannot be used in private messages."),
-                False,
-            )
-
-        if isinstance(error, commands.NSFWChannelRequired):
-            return (
-                _(ctx, "NSFW Channel Required"),
-                _(ctx, "This command can be used only in NSFW channels."),
-                False,
-            )
-
-        # extensions
-        if type(error) == commands.ExtensionFailed:
-            # return friendly name, e.g. strip "modules.{module}.module"
-            name = error.name[8:-7]
-            return (
-                _(ctx, "Extension Error"),
-                _(ctx, "An error occurred inside of **{extension}** extension").format(
-                    extension=name,
-                ),
-                True,
-            )
-        if isinstance(error, commands.ExtensionError):
-            # return friendly name, e.g. strip "modules.{module}.module"
-            name = error.name[8:-7]
-            # send helpful message if the requested module does not follow naming rules
-            if re.fullmatch(r"([a-z_]+)\.([a-z_]+)", name) is None:
-                key = "ExtensionNotFound_hint"
-            else:
-                key = type(error).__name__
-            error_message = {
-                "ExtensionAlreadyLoaded": _(
-                    ctx, "Extension **{extension}** is already loaded"
-                ).format(
-                    extension=name,
-                ),
-                "ExtensionError": _(
-                    ctx, "An error occurred inside of **{extension}** extension"
-                ).format(
-                    extension=name,
-                ),
-                "ExtensionFailed": _(ctx, "**{extension}** failed").format(
-                    extension=name
-                ),
-                "ExtensionNotFound": _(
-                    ctx, "The extension **{extension}** could not be found"
-                ).format(
-                    extension=name,
-                ),
-                "ExtensionNotFound_hint": _(
-                    ctx,
-                    "The extension **{extension}** could not be found. It should be in `repository.module` format",
-                ).format(
-                    extension=name,
-                ),
-                "ExtensionNotLoaded": _(
-                    ctx, "The extension **{extension}** is not loaded"
-                ).format(
-                    extension=name,
-                ),
-            }
-            return (
-                _(ctx, "Extension Error"),
-                error_message.get(key, _(ctx, "An unexpected error occurred"))
-                + ":\n"
-                + str(error),
-                False,
-            )
-
-        # the rest of client exceptions
-        if type(error) == commands.CommandRegistrationError:
-            return (
-                _(ctx, "Error"),
-                _(ctx, "Error on registering the command `{cmd}`").format(
-                    cmd=error.name
-                ),
-                False,
-            )
-        if isinstance(error, commands.UserInputError):
-            return (
-                _(ctx, "Command error"),
-                _(ctx, "Bad input"),
-                False,
-            )
-        if isinstance(error, commands.CommandError) or isinstance(
-            error, nextcord.ClientException
-        ):
-            error_message = {
-                "CommandError": _(ctx, "Command error"),
-                "ClientException": _(ctx, "Client error"),
-            }
-            return (
-                _(ctx, "Error"),
-                error_message.get(
-                    type(error).__name__, _(ctx, "An unexpected error occurred")
-                ),
-                True,
-            )
-
-        # non-critical nextcord exceptions
-        if type(error) == nextcord.NoMoreItems or isinstance(
-            error, nextcord.HTTPException
-        ):
-            error_message = {
-                "NoMoreItems": _(ctx, "pumpkin.py exception"),
-                "HTTPException": _(ctx, "An environment variable is missing"),
-            }
-            return (
-                _(ctx, "Error"),
-                error_message.get(
-                    type(error).__name__, _(ctx, "An unexpected error occurred")
-                ),
-                True,
-            )
-
-        # critical nextcord exceptions
-        if isinstance(error, nextcord.DiscordException):
-            return (
-                _(ctx, "Error"),
-                _(ctx, "nextcord library error"),
-                True,
-            )
-
-        # other exceptions
-        return (
-            type(error).__name__,
-            _(ctx, "An unexpected error occurred"),
-            True,
-        )
 
 
 def setup(bot) -> None:

--- a/modules/base/errors/module.py
+++ b/modules/base/errors/module.py
@@ -1,5 +1,4 @@
 import re
-import traceback
 from typing import Tuple
 
 import nextcord
@@ -31,11 +30,6 @@ class Errors(commands.Cog):
         self.bot = bot
 
     @commands.Cog.listener()
-    async def on_error(event, *args, **kwargs):
-        tb = traceback.format_exc()
-        await bot_log.error(None, None, traceback=tb)
-
-    @commands.Cog.listener()
     async def on_command_error(
         self, ctx: commands.Context, error: commands.CommandError
     ):
@@ -45,11 +39,13 @@ class Errors(commands.Cog):
             return
 
         # Get original exception
-        while True:
-            new_error = getattr(error, "original", error)
-            if new_error == error:
-                break
-            error = new_error
+        error = getattr(error, "original", error)
+
+        # Getting the *original* exception is difficult.
+        # Because of how the library is built, walking up the stacktrace gets messy
+        # by entering '_run_event' and other internal functions. This means that this
+        # 'error' is the last line that raised an exception, not the initial cause.
+        # Tracebacks are logged, this is good enough.
 
         if type(error) in IGNORED_EXCEPTIONS:
             return

--- a/modules/base/po/cs.popie
+++ b/modules/base/po/cs.popie
@@ -295,9 +295,6 @@ msgstr Čas spuštění
 msgid Run time
 msgstr Doba od spuštění
 
-msgid Error content
-msgstr
-
 msgid pumpkin.py exception
 msgstr Výjimka pumpkin.py
 
@@ -310,98 +307,59 @@ msgstr Výjimka modulu
 msgid Translation error
 msgstr Chyba překladu
 
-msgid Command error
-msgstr Chyba příkazu
+msgid Error
+msgstr Chyba
 
-msgid The command has to have an argument `{arg}`
-msgstr Příkaz musí mít argument `{arg}`
+msgid Gateway not found
+msgstr Brána nebyla nalezena
 
-msgid Permission error
-msgstr Chyba oprávnění
+msgid Nextcord library error
+msgstr Chyba nextcord knihovny
 
-msgid Insufficient permission
-msgstr Nedostatečné oprávnění
+msgid Client error
+msgstr Chyba klienta
 
-msgid Slow down
-msgstr Zpomal
+msgid Invalid data
+msgstr Chybná data
 
-msgid Wait **{time}**
-msgstr Počkej **{time}**
+msgid Invalid argument
+msgstr Chybný argument
 
-msgid Too much concurrency
-msgstr
+msgid Login failure
+msgstr Přihlašovací chyba
 
-msgid This command is already running multiple times
-msgstr Tento příkaz už několikrát běží
+msgid Connection closed
+msgstr Spojení ukončeno
 
-msgid The limit is **{num}**/**{per}**
-msgstr Limit je **{num}**/**{per}**
+msgid Privileged intents required
+msgstr Privilegované záměry požadovány
 
-msgid You have to have a {role} role for that
-msgstr Na toto musíš mít roli {role}
+msgid Error on registering the command `{cmd}`
+msgstr Chyba při registraci příkazu `{cmd}`
 
-msgid I lack the role {role}
-msgstr Chybí mi role {role}
+msgid HTTP Exception
+msgstr HTTP chyba
 
-msgid You have to have one role of {roles}
-msgstr Musíš mít jednu z rolí {roles}
+msgid Forbidden
+msgstr Zakázáno
 
-msgid I need one of roles {roles}
-msgstr Potřebuji jednu z rolí {roles}
-
-msgid You lack some of {perms} permissions
-msgstr Chybí ti některá z těchto oprávnění {perms}
-
-msgid I lack the {perms} permission
-msgstr Chybí mi oprávnění {perms}
-
-msgid Argument error
-msgstr Chyba argumentu
-
-msgid Bad data type in the `{param}` parameter
-msgstr Nesprávný datový typ v parametru `{param}`
-
-msgid Bad Boolean Argument
-msgstr Nesprávný binární argument
-
-msgid Argument `{arg}` is not binary
-msgstr Argument `{arg}` není binární
-
-msgid An error occurred in converter `{converter}`
-msgstr Stala se chyba v konvertoru `{converter}`
-
-msgid Not found
+msgid NotFound
 msgstr Nenalezeno
 
-msgid I can't see the **{channel}** channel
-msgstr Nevidím kanál **{channel}**
+msgid Discord Server Error
+msgstr Chyba Discord serveru
 
-msgid Bad Argument
-msgstr Nesprávný argument
-
-msgid Error in argument
-msgstr Chyba v argumentu
-
-msgid No Private Message
-msgstr Nelze použít v soukromém kanálu
-
-msgid This command cannot be used in private messages.
-msgstr Tenhle příkaz nemůže být použit v soukromém kanálu.
-
-msgid NSFW Channel Required
-msgstr Vyžadován NSFW kanál
-
-msgid This command can be used only in NSFW channels.
-msgstr Tenhle příkaz může být použit pouze v NSFW kanálech.
-
-msgid Extension Error
-msgstr Chyba rozšíření
-
-msgid An error occurred inside of **{extension}** extension
-msgstr Stala se chyba v rozšíření **{extension}**
+msgid The extension **{extension}** could not be found. It should be in `repository.module` format
+msgstr Rozšíření **{extension}** nebylo nalezeno. Mělo by to být ve formátu `repository.module`
 
 msgid Extension **{extension}** is already loaded
 msgstr Rozšíření **{extension}** je už načteno
+
+msgid The extension **{extension}** is not loaded
+msgstr Rozšíření **{extension}** není načteno
+
+msgid Extension **{extension}** doesn't have a setup entry function
+msgstr Rozšíření **{extension}** nemá vstupní setup funkci
 
 msgid **{extension}** failed
 msgstr **{extension}** selhalo
@@ -409,26 +367,131 @@ msgstr **{extension}** selhalo
 msgid The extension **{extension}** could not be found
 msgstr Nebylo nalezeno rozšíření **{extension}**
 
-msgid The extension **{extension}** could not be found. It should be in `repository.module` format
-msgstr Rozšíření **{extension}** nebylo nalezeno. Mělo by to být ve formátu `repository.module`
+msgid Extension error
+msgstr Chyba rozšíření
 
-msgid The extension **{extension}** is not loaded
-msgstr Rozšíření **{extension}** není načteno
+msgid Extension Error
+msgstr Chyba rozšíření
 
-msgid Error
-msgstr Chyba
+msgid Command error
+msgstr Chyba příkazu
 
-msgid Error on registering the command `{cmd}`
-msgstr Chyba při registraci příkazu `{cmd}`
+msgid An error occurred in converter `{converter}`
+msgstr Stala se chyba v konvertoru `{converter}`
 
-msgid Bad input
-msgstr Nesprávný vstup
+msgid Command not found
+msgstr Příkaz nenalezen
 
-msgid Client error
-msgstr Chyba klienta
+msgid Disabled command
+msgstr Příkaz deaktivován
 
-msgid nextcord library error
-msgstr Chyba knihovny nextcord
+msgid Command invoke error
+msgstr Chyba ve volání příkazy
+
+msgid Slow down. Wait **{time}**
+msgstr Zpomal. Počkej **{time}**
+
+msgid This command is already running multiple times
+msgstr Tento příkaz už několikrát běží.
+
+msgid The limit is **{num}**/**{per}**
+msgstr Limit je **{num}**/**{per}**
+
+msgid Check failure
+msgstr Chyba kontroly
+
+msgid You do not have any of the possible permissions to access this command
+msgstr Nemáš žádné z možných oprávnění k tomuto příkazu
+
+msgid This command can only be used in private messages.
+msgstr Tento příkaz lze pouze použít v privátních zprávách
+
+msgid This command cannot be used in private messages.
+msgstr Tento příkaz nelze pouze použít v privátních zprávách
+
+msgid You are not the bot owner
+msgstr Nejsi vlastník bota
+
+msgid You lack some of {perms} permissions
+msgstr Chybí ti některé z {perms} oprávnění
+
+msgid I lack the {perms} permission
+msgstr Chybí mi  {perms} oprávnění
+
+msgid You have to have a {role} role for that
+msgstr K tomuto potřebuješ roli {role}
+
+msgid I lack the role {role}
+msgstr Chybí mi role {role}
+
+msgid You have to have one role of {roles}
+msgstr K tomuto potřebuješ některou roli z {roles}
+
+msgid I need one of roles {roles}
+msgstr Potřebuji některou roli z {roles}
+
+msgid This command can be used only in NSFW channels.
+msgstr Tento příkaz nelze pouze použít v NSFW kanálech
+
+msgid User input error
+msgstr Chyba uživatelského vstupu
+
+msgid The command has to have an argument `{arg}`
+msgstr Příkaz musí mít argument `{arg}`
+
+msgid The command doesn't have that many arguments.
+msgstr Příkaz nemá tolik argumentů
+
+msgid Bad argument
+msgstr Špatný argument
+
+msgid Message not found
+msgstr Zpráva nenalezena
+
+msgid Member not found
+msgstr Člen nenalezen
+
+msgid User not found
+msgstr Uživatel nenalezen
+
+msgid Channel not found
+msgstr Kanál nenalezen
+
+msgid I can't see the **{channel}** channel
+msgstr Nevidím kanál **{channel}**
+
+msgid Bad colour argument
+msgstr Špatný argument barvy
+
+msgid Role not found
+msgstr Role nenalezena
+
+msgid Bad invite argument
+msgstr Špatný argument pozvánky
+
+msgid Emoji not found
+msgstr Emoji nenalezeno
+
+msgid PartialEmoji conversion failure
+msgstr Chyba převodu na PartialEmoji
+
+msgid Bad bool argument
+msgstr Špatný True/False argument
+
+msgid Bad Union argument
+msgstr Špatný argument sjednocení
+
+msgid Argument parsing error
+msgstr Chyba čtení argumentu
+
+msgid Unexpected quote error
+msgstr Neočekávané uvozovky
+
+msgid Invalid end of quoted string error
+msgstr Chybný konec textu v uvozovkách
+
+msgid Error content
+msgstr
 
 msgid Localization
 msgstr Lokalizace

--- a/modules/base/po/sk.popie
+++ b/modules/base/po/sk.popie
@@ -311,43 +311,43 @@ msgid Error
 msgstr Chyba
 
 msgid Gateway not found
-msgstr
+msgstr Brána nebola nájdená
 
 msgid Nextcord library error
-msgstr
+msgstr Chyba nexcord knižnice
 
 msgid Client error
 msgstr Chyba klienta
 
 msgid Invalid data
-msgstr
+msgstr Chybné dáta
 
 msgid Invalid argument
-msgstr
+msgstr Chýbný argument
 
 msgid Login failure
-msgstr
+msgstr Prihlasovacia chyba
 
 msgid Connection closed
-msgstr
+msgstr Spojenie ukončené
 
 msgid Privileged intents required
-msgstr
+msgstr Požadované privilegované zámery
 
 msgid Error on registering the command `{cmd}`
 msgstr Chyba pri registrácii príkazu `{cmd}`
 
 msgid HTTP Exception
-msgstr
+msgstr HTTP chyba
 
 msgid Forbidden
-msgstr
+msgstr Zakázané
 
 msgid NotFound
-msgstr
+msgstr Nenájdené
 
 msgid Discord Server Error
-msgstr
+msgstr Chyba Discord servera
 
 msgid The extension **{extension}** could not be found. It should be in `repository.module` format
 msgstr Rozšírenie **{extension}** nebolo nájdené. Malo by byť vo formáte `repository.module`
@@ -368,7 +368,7 @@ msgid The extension **{extension}** could not be found
 msgstr Nebolo nájdené rozšírenie **{extension}**
 
 msgid Extension error
-msgstr
+msgstr Chyba rozšírenia
 
 msgid Extension Error
 msgstr Chyba rozšírenia
@@ -380,115 +380,115 @@ msgid An error occurred in converter `{converter}`
 msgstr Stala se chyba v konvertori `{converter}`
 
 msgid Command not found
-msgstr
+msgstr Príkaz nenájdený
 
 msgid Disabled command
-msgstr
+msgstr Príkaz deaktivovaný
 
 msgid Command invoke error
-msgstr
+msgstr Chyba pri volaní príkazu
 
 msgid Slow down. Wait **{time}**
-msgstr
+msgstr Spomal. Počkaj **{time}**
 
 msgid This command is already running multiple times
-msgstr
+msgstr Tento príkaz už beží niekoľko krát
 
 msgid The limit is **{num}**/**{per}**
-msgstr
+msgstr Limit je **{num}**/**{per}**
 
 msgid Check failure
-msgstr
+msgstr Chyba kontroly
 
 msgid You do not have any of the possible permissions to access this command
-msgstr
+msgstr Nemáš žiadne z možných oprávnení k tomuto príkazu
 
 msgid This command can only be used in private messages.
-msgstr
+msgstr Tento príkaz je možné použiť len v súkromých správach.
 
 msgid This command cannot be used in private messages.
-msgstr
+msgstr Tento príkaz nie je možné použiť v súkromných správach.
 
 msgid You are not the bot owner
-msgstr
+msgstr Nie si vlastník bota
 
 msgid You lack some of {perms} permissions
-msgstr
+msgstr Chýba ti niektoré z {perms} oprávnení
 
 msgid I lack the {perms} permission
-msgstr
+msgstr Chýba mi {perms} oprávnenie
 
 msgid You have to have a {role} role for that
-msgstr
+msgstr K tomuto potrebuješ rolu {role}
 
 msgid I lack the role {role}
-msgstr
+msgstr Chýba mi rola {role}
 
 msgid You have to have one role of {roles}
-msgstr
+msgstr K tomuto potrebuješ niektorú z rolí {roles}
 
 msgid I need one of roles {roles}
-msgstr
+msgstr Potrebujem niektorú rolu z {roles}
 
 msgid This command can be used only in NSFW channels.
-msgstr
+msgstr Tento príkaz môže byť použitý len v NSFW kanáloch.
 
 msgid User input error
-msgstr
+msgstr Chyba užívateľského vstupu
 
 msgid The command has to have an argument `{arg}`
-msgstr
+msgstr Príkaz musí mať argument `{arg}`
 
 msgid The command doesn't have that many arguments.
-msgstr
+msgstr Príkaz nemá toľko argumentov.
 
 msgid Bad argument
-msgstr
+msgstr Zlý argument
 
 msgid Message not found
-msgstr
+msgstr Správa nenájdená
 
 msgid Member not found
-msgstr
+msgstr Člen nenájdený
 
 msgid User not found
-msgstr
+msgstr Užívateľ nenájdený
 
 msgid Channel not found
-msgstr
+msgstr Kanál nenájdený
 
 msgid I can't see the **{channel}** channel
-msgstr
+msgstr Nevidím kanál **{channel}**
 
 msgid Bad colour argument
-msgstr
+msgstr Zlý argument farby
 
 msgid Role not found
-msgstr
+msgstr Rola nenájdená
 
 msgid Bad invite argument
-msgstr
+msgstr Zlý argument pozvánky
 
 msgid Emoji not found
-msgstr
+msgstr Emoji nenájdený
 
 msgid PartialEmoji conversion failure
-msgstr
+msgstr Chyba prevodu na PartialEmoji
 
 msgid Bad bool argument
-msgstr
+msgstr Zlý True/False argument
 
 msgid Bad Union argument
-msgstr
+msgstr Zlý argument zjednotenia
 
 msgid Argument parsing error
-msgstr
+msgstr Chyba čítania argumentu
 
 msgid Unexpected quote error
-msgstr
+msgstr Neočakávané úvodzovky
 
 msgid Invalid end of quoted string error
-msgstr
+msgstr Chybný koniec textu v úvodzovkách
 
 msgid Error content
 msgstr Obsah chyby

--- a/modules/base/po/sk.popie
+++ b/modules/base/po/sk.popie
@@ -295,9 +295,6 @@ msgstr Čas spustenia
 msgid Run time
 msgstr Doba od spustenia
 
-msgid Error content
-msgstr Obsah chyby
-
 msgid pumpkin.py exception
 msgstr Výnimka pumpkin.py
 
@@ -310,98 +307,59 @@ msgstr Výnimka modulu
 msgid Translation error
 msgstr Chyba prekladu
 
-msgid Command error
-msgstr Chyba príkazu
+msgid Error
+msgstr Chyba
 
-msgid The command has to have an argument `{arg}`
-msgstr Príkaz musí mať argument `{arg}`
+msgid Gateway not found
+msgstr
 
-msgid Permission error
-msgstr Chyba oprávnenia
+msgid Nextcord library error
+msgstr
 
-msgid Insufficient permission
-msgstr Nedostatočné oprávnenie
+msgid Client error
+msgstr Chyba klienta
 
-msgid Slow down
-msgstr Spomaľ
+msgid Invalid data
+msgstr
 
-msgid Wait **{time}**
-msgstr Počkaj **{time}**
+msgid Invalid argument
+msgstr
 
-msgid Too much concurrency
-msgstr Príliš veľa súbežností
+msgid Login failure
+msgstr
 
-msgid This command is already running multiple times
-msgstr Tento príkaz už niekoľkokrát beží
+msgid Connection closed
+msgstr
 
-msgid The limit is **{num}**/**{per}**
-msgstr Limit je **{num}**/**{per}**
+msgid Privileged intents required
+msgstr
 
-msgid You have to have a {role} role for that
-msgstr Na toto musíš mať rolu {role}
+msgid Error on registering the command `{cmd}`
+msgstr Chyba pri registrácii príkazu `{cmd}`
 
-msgid I lack the role {role}
-msgstr Chýba mi rola {role}
+msgid HTTP Exception
+msgstr
 
-msgid You have to have one role of {roles}
-msgstr Musíš mať jednu z rolí {roles}
+msgid Forbidden
+msgstr
 
-msgid I need one of roles {roles}
-msgstr Potrebujem jednu z rolí {roles}
+msgid NotFound
+msgstr
 
-msgid You lack some of {perms} permissions
-msgstr Chýba ti niektoré z týchto oprávnení {perms}
+msgid Discord Server Error
+msgstr
 
-msgid I lack the {perms} permission
-msgstr Chýba mi oprávnenie {perms}
-
-msgid Argument error
-msgstr Chyba argumentu
-
-msgid Bad data type in the `{param}` parameter
-msgstr Nesprávny datový typ v parametri `{param}`
-
-msgid Bad Boolean Argument
-msgstr Nesprávny binárny argument
-
-msgid Argument `{arg}` is not binary
-msgstr Argument `{arg}` nie je binárny
-
-msgid An error occurred in converter `{converter}`
-msgstr Stala se chyba v konvertori `{converter}`
-
-msgid Not found
-msgstr Nanájdené
-
-msgid I can't see the **{channel}** channel
-msgstr Nevidím kanál **{channel}**
-
-msgid Bad Argument
-msgstr Nesprávny argument
-
-msgid Error in argument
-msgstr Chyba v argumente
-
-msgid No Private Message
-msgstr Nedá sa použiť v súkromnom kanáli
-
-msgid This command cannot be used in private messages.
-msgstr Tento príkaz nemôže byť použitý v súkromnom kanáli.
-
-msgid NSFW Channel Required
-msgstr Vyžadovaný NSFW kanál
-
-msgid This command can be used only in NSFW channels.
-msgstr Tento príkaz môže byť použitý iba v NSFW kanáloch.
-
-msgid Extension Error
-msgstr Chyba rozšírenia
-
-msgid An error occurred inside of **{extension}** extension
-msgstr Stala se chyba v rozšírení **{extension}**
+msgid The extension **{extension}** could not be found. It should be in `repository.module` format
+msgstr Rozšírenie **{extension}** nebolo nájdené. Malo by byť vo formáte `repository.module`
 
 msgid Extension **{extension}** is already loaded
 msgstr Rozšírenie **{extension}** je už načítané
+
+msgid The extension **{extension}** is not loaded
+msgstr Rozšírenie **{extension}** nie je načítané
+
+msgid Extension **{extension}** doesn't have a setup entry function
+msgstr Rozšírenie **{extension}** nemá vstupnú setup funkciu
 
 msgid **{extension}** failed
 msgstr **{extension}** zlyhalo
@@ -409,26 +367,131 @@ msgstr **{extension}** zlyhalo
 msgid The extension **{extension}** could not be found
 msgstr Nebolo nájdené rozšírenie **{extension}**
 
-msgid The extension **{extension}** could not be found. It should be in `repository.module` format
-msgstr Rozšírenie **{extension}** nebolo nájdené. Malo by byť vo formáte `repository.module`
+msgid Extension error
+msgstr
 
-msgid The extension **{extension}** is not loaded
-msgstr Rozšírenie **{extension}** nie je načítané
+msgid Extension Error
+msgstr Chyba rozšírenia
 
-msgid Error
-msgstr Chyba
+msgid Command error
+msgstr Chyba príkazu
 
-msgid Error on registering the command `{cmd}`
-msgstr Chyba pri registrácii príkazu `{cmd}`
+msgid An error occurred in converter `{converter}`
+msgstr Stala se chyba v konvertori `{converter}`
 
-msgid Bad input
-msgstr Nesprávny vstup
+msgid Command not found
+msgstr
 
-msgid Client error
-msgstr Chyba klienta
+msgid Disabled command
+msgstr
 
-msgid nextcord library error
-msgstr Chyba knižnice nextcord
+msgid Command invoke error
+msgstr
+
+msgid Slow down. Wait **{time}**
+msgstr
+
+msgid This command is already running multiple times
+msgstr
+
+msgid The limit is **{num}**/**{per}**
+msgstr
+
+msgid Check failure
+msgstr
+
+msgid You do not have any of the possible permissions to access this command
+msgstr
+
+msgid This command can only be used in private messages.
+msgstr
+
+msgid This command cannot be used in private messages.
+msgstr
+
+msgid You are not the bot owner
+msgstr
+
+msgid You lack some of {perms} permissions
+msgstr
+
+msgid I lack the {perms} permission
+msgstr
+
+msgid You have to have a {role} role for that
+msgstr
+
+msgid I lack the role {role}
+msgstr
+
+msgid You have to have one role of {roles}
+msgstr
+
+msgid I need one of roles {roles}
+msgstr
+
+msgid This command can be used only in NSFW channels.
+msgstr
+
+msgid User input error
+msgstr
+
+msgid The command has to have an argument `{arg}`
+msgstr
+
+msgid The command doesn't have that many arguments.
+msgstr
+
+msgid Bad argument
+msgstr
+
+msgid Message not found
+msgstr
+
+msgid Member not found
+msgstr
+
+msgid User not found
+msgstr
+
+msgid Channel not found
+msgstr
+
+msgid I can't see the **{channel}** channel
+msgstr
+
+msgid Bad colour argument
+msgstr
+
+msgid Role not found
+msgstr
+
+msgid Bad invite argument
+msgstr
+
+msgid Emoji not found
+msgstr
+
+msgid PartialEmoji conversion failure
+msgstr
+
+msgid Bad bool argument
+msgstr
+
+msgid Bad Union argument
+msgstr
+
+msgid Argument parsing error
+msgstr
+
+msgid Unexpected quote error
+msgstr
+
+msgid Invalid end of quoted string error
+msgstr
+
+msgid Error content
+msgstr Obsah chyby
 
 msgid Localization
 msgstr Lokalizácia

--- a/pumpkin.py
+++ b/pumpkin.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import sqlalchemy
 
 import nextcord
 from nextcord.ext import commands
@@ -98,6 +99,24 @@ async def on_ready():
     else:
         await bot_log.info(None, None, "The pie is ready.")
         already_loaded = True
+
+
+async def on_error(event, *args, **kwargs):
+    error_type, error, tb = sys.exc_info()
+
+    # Make sure we rollback the database session if we encounter an error
+    if isinstance(error, sqlalchemy.exc.SQLAlchemyError):
+        database.session.rollback()
+        database.session.commit()
+        await bot_log.critical(
+            None,
+            None,
+            "pumpkin.py database session rolled back. The bubbled-up cause is:\n"
+            + "\n".join([f"| {line}" for line in str(error).split("\n")]),
+        )
+
+
+commands.Bot.on_error = on_error
 
 
 # Add required modules


### PR DESCRIPTION
I reworked the error handling. It should be more readable and extensible now.

All nextcord related exceptions should be handled separately and any other exception is handled as an unknown error.

I created the CZ popie, so someone needs to take a look at the SK variant too. Once that is finished and @sinus-x takes a look at the recursion prevention stuff we can merge this.

