### PR TITLE
Help: Add '...' after help's subcommand if it is command group

### DIFF
--- a/pie/help.py
+++ b/pie/help.py
@@ -126,10 +126,12 @@ class Help(commands.MinimalHelpCommand):
         This override renders the subcommand as en dash followed by
         qualified name.
         """
-        line = f"\N{EN DASH} **{command.qualified_name}**"
+        line = f"\N{EM DASH} **{command.qualified_name}**"
+        if type(command) is commands.Group:
+            line += " ..."
         # TODO Update we have a way to translate command descriptions
         if command.short_doc:
-            line += f": *{command.short_doc}*"
+            line += f" \N{EN DASH} *{command.short_doc}*"
 
         self.paginator.add_line(line)
 


### PR DESCRIPTION
Previously the help did not show any difference between commands and
command groups:

> – **acl mapping**: Manage mapping of ACL levels to roles.
> – **acl overwrite-list**: Display active overwrites.

Now, ellipsis has been added after the names of command groups, and
en dash is used instead of colon to help separate the content:

> — **acl mapping** ... – Manage mapping of ACL levels to roles.
> — **acl overwrite-list** – Display active overwrites.