### PR TITLE
Add global value storage

### DIFF
--- a/pie/database/__init__.py
+++ b/pie/database/__init__.py
@@ -31,7 +31,7 @@ def init_core():
     importlib.import_module("pie.database.config")
     database.base.metadata.create_all(database.db)
 
-    for module in ("acl", "i18n", "logger", "spamchannel"):
+    for module in ("acl", "i18n", "logger", "storage", "spamchannel"):
         import_stub: str = f"pie.{module}.database"
         try:
             importlib.import_module(import_stub)

--- a/pie/storage/__init__.py
+++ b/pie/storage/__init__.py
@@ -137,11 +137,6 @@ def unset(module: commands.Cog, guild_id: int, key: str):
         True if succesfuly deleted, False if not found
     """
 
-    db_value = StorageData.get(module.qualified_name, guild_id, key)
+    deleted = StorageData.remove(module.qualified_name, guild_id, key)
 
-    if not db_value:
-        return False
-
-    db_value.delete()
-
-    return True
+    return deleted

--- a/pie/storage/__init__.py
+++ b/pie/storage/__init__.py
@@ -13,7 +13,7 @@ def get(module: commands.Cog, guild_id: int, key: str, default_value=None) -> An
     For saving global data (non-guild related) set guild_id to 0.
 
     If value is not found in DB or it's type is unknown,
-    it returns default_value, which if not set is None.
+    it returns default_value, None by default.
 
     Args:
         module (:class:`nextcord.ext.commands.Cog`): module connected with the value

--- a/pie/storage/__init__.py
+++ b/pie/storage/__init__.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from pydoc import locate
+from typing import Any
+
+from nextcord.ext import commands
+
+from pie.storage.database import StorageData
+
+
+def get(module: commands.Cog, guild_id: int, key: str, default_value=None) -> Any:
+    """Get data from persistant DataStorage base on module and guild.
+    For saving global data (non-guild related) set guild_id to 0.
+
+    If value is not found in DB or it's type is unknown,
+    it returns default_value, which if not set is None.
+
+    Args:
+        module (:class:`nextcord.ext.commands.Cog`): module connected with the value
+        guild_id (:class:'int'): ID of guild connected with the value (0 for global)
+        key (:class:'str'): Value's key
+        default_value: This argument is returned if value is not found in database
+
+    Returns:
+        Any: value stored in DB
+
+    Raises:
+        ValueError: Raised if value type change fails
+    """
+
+    db_value = StorageData.get(module.qualified_name, guild_id, key)
+    if not db_value:
+        return default_value
+
+    t = locate(db_value.type)
+
+    if not t:
+        return default_value
+
+    value = t(db_value.value)
+
+    return value
+
+
+def exists(module: commands.Cog, guild_id: int, key: str) -> bool:
+    """Checks if data for module, key and guild_id combination
+    are present in DB.
+
+    Args:
+        module (:class:`nextcord.ext.commands.Cog`): module connected with the value
+        guild_id (:class:'int'): ID of guild connected with the value (0 for global)
+        key (:class:'str'): Value's key
+
+        Returns:
+            True if value exists in DB, False otherwise
+    """
+
+    db_value = StorageData.get(module.qualified_name, guild_id, key)
+
+    return db_value is not None
+
+
+def get_type(module: commands.Cog, guild_id: int, key: str) -> type:
+    """Get data type.
+
+    Args:
+        module (:class:`nextcord.ext.commands.Cog`): module connected with the value
+        guild_id (:class:'int'): ID of guild connected with the value (0 for global)
+        key (:class:'str'): Value's key
+
+    Returns:
+        Value data type, None if type is not find
+    """
+
+    db_value = StorageData.get(module.qualified_name, guild_id, key)
+
+    if not db_value:
+        return None
+
+    t = locate(db_value.type)
+
+    return t
+
+
+def set(module: commands.Cog, guild_id: int, key: str, value: object) -> bool:
+    """Stores value into DB. If data exists, it's overwriten.
+
+    This is designed for basic data types (int, float, bool, string).
+    Using this for any other data types can cause problems!
+
+    Args:
+        module (:class:`nextcord.ext.commands.Cog`): module connected with the value
+        guild_id (:class:'int'): ID of guild connected with the value (0 for global)
+        key (:class:'str'): Value's key
+        value (:class: `typing.Any`): Value to store in DB
+
+    Returns:
+        True if succesfuly saved, False otherwise
+    """
+
+    return StorageData.set(module.qualified_name, guild_id, key, value) is not None
+
+
+def set_if_missing(module: commands.Cog, guild_id: int, key: str, value: Any) -> bool:
+    """Stores value into DB. If value exists, it's ignored.
+
+    This is designed for basic data types (int, float, bool, string).
+    Using this for any other data types can cause problems!
+
+    Args:
+        module (:class:`nextcord.ext.commands.Cog`): module connected with the value
+        guild_id (:class:'int'): ID of guild connected with the value (0 for global)
+        key (:class:'str'): Value's key
+        value (:class: `typing.Any`): Value to store in DB
+
+    Returns:
+        True if succesfuly saved, False otherwise
+    """
+
+    return (
+        StorageData.set(
+            module.qualified_name, guild_id, key, value, allow_overwrite=False
+        )
+        is not None
+    )
+
+
+def unset(module: commands.Cog, guild_id: int, key: str):
+    """Delete module's stored data by guild and key.
+
+    Args:
+        module (:class:`nextcord.ext.commands.Cog`): module connected with the value
+        guild_id (:class:'int'): ID of guild connected with the value (0 for global)
+        key (:class:'str'): Value's key
+
+    Returns:
+        True if succesfuly deleted, False if not found
+    """
+
+    db_value = StorageData.get(module.qualified_name, guild_id, key)
+
+    if not db_value:
+        return False
+
+    db_value.delete()
+
+    return True

--- a/pie/storage/database.py
+++ b/pie/storage/database.py
@@ -50,15 +50,22 @@ class StorageData(database.base):
         data = (
             session.query(StorageData)
             .filter_by(module=module)
-            .filter_by(key=key)
             .filter_by(guild_id=guild_id)
+            .filter_by(key=key)
             .one_or_none()
         )
         return data
 
-    def delete(self):
-        session.delete(self)
+    @classmethod
+    def remove(module: str, guild_id: int, key: str) -> bool:
+        count = (
+            session.get(StorageData)
+            .filter_by(module=module, guild_id=guild_id, key=key)
+            .delete()
+        )
         session.commit()
+
+        return count == 1
 
     def __repr__(self) -> str:
         return (

--- a/pie/storage/database.py
+++ b/pie/storage/database.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from typing import Dict, Optional, Union
+
+from sqlalchemy import BigInteger, Column, String
+
+from pie.database import database, session
+
+
+class StorageData(database.base):
+    __tablename__ = "pie_storage_data"
+
+    module = Column(String, primary_key=True)
+    guild_id = Column(BigInteger, primary_key=True)
+    key = Column(String, primary_key=True)
+    value = Column(String)
+    type = Column(String)
+
+    @staticmethod
+    def set(
+        module: str,
+        guild_id: int,
+        key: str,
+        value,
+        allow_overwrite: bool = True,
+    ) -> Optional[StorageData]:
+        data = (
+            session.query(StorageData)
+            .filter_by(module=module)
+            .filter_by(guild_id=guild_id)
+            .filter_by(key=key)
+            .one_or_none()
+        )
+
+        if data and not allow_overwrite:
+            return None
+
+        if not data:
+            data = StorageData(module=module, key=key, guild_id=guild_id)
+
+        data.value = value
+        data.type = type(value).__name__
+        session.merge(data)
+        session.commit()
+
+        return data
+
+    @staticmethod
+    def get(module: str, guild_id: int, key: str) -> Optional[StorageData]:
+        data = (
+            session.query(StorageData)
+            .filter_by(module=module)
+            .filter_by(key=key)
+            .filter_by(guild_id=guild_id)
+            .one_or_none()
+        )
+        return data
+
+    def delete(self):
+        session.delete(self)
+        session.commit()
+
+    def __repr__(self) -> str:
+        return (
+            f'<StorageData module="{self.module}" guild_id="{self.guild_id}" key="{self.key}" '
+            f'value="{self.value}" type="{self.type}">'
+        )
+
+    def dump(self) -> Dict[str, Union[int, str]]:
+        """Return object representation as dictionary for easy serialisation."""
+        return {
+            "module": self.module,
+            "guild_id": self.guild_id,
+            "key": self.key,
+            "value": self.value,
+        }


### PR DESCRIPTION
I think it's not a good idea to create whole DB for one key-value configurable pair. For this reason I've come with this - Pie core util called Storage, that would provide dev's their own space for few key-value pairs, such as basic bot or guild configs for functions.

This is my first idea and it's to discuss if there's anything to change. It's still untested.