### PR TITLE
Core: Do not ignore extra arguments

### DIFF
--- a/pumpkin.py
+++ b/pumpkin.py
@@ -165,6 +165,9 @@ for module in db_modules:
         continue
     print("Loaded module " + module.name, file=sys.stdout)  # noqa: T001
 
+for command in bot.walk_commands():
+    if type(command) is not commands.Group:
+        command.ignore_extra = False
 
 # Run the bot
 


### PR DESCRIPTION
This change enables sets 'ignore_extra' attribute of all non-group
commands to False. When this is applied, bot won't allow additional
words after all known arguments (greedy '*' still works).

Only minority of commands will need to be changed -- 'fun:flip' for
example.