### PR TITLE
Docker: Move backup env to .env

### DIFF
--- a/default.docker.env
+++ b/default.docker.env
@@ -1,3 +1,10 @@
 DB_STRING=postgresql://postgres:postgres@db:5432/postgres
 DOCKER_DB_BACKUP_PATH=/var/opt/pumpkin-backups
 TOKEN=
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_HOST=db
+POSTGRES_PORT=5432
+POSTGRES_DB=postgres
+POSTGRES_EXTRA_OPTS=-Z9 --schema=public --blobs
+SCHEDULE=@every 3h00m00s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,13 +20,7 @@ services:
       - db
     depends_on:
       - db
-    environment:
-      - POSTGRES_HOST=db
-      - POSTGRES_DB=postgres
-      - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=postgres
-      - POSTGRES_EXTRA_OPTS=-Z9 --schema=public --blobs
-      - SCHEDULE=@every 3h00m00s
+    env_file: .env
   bot:
     build:
       context: .


### PR DESCRIPTION
If you are using other than provided PostgreSQL server in docker or with different settings, you might run into trouble that automatic backup is useless. This solves the problem by moving backup environment settings into .env file.