### PR TITLE
Admin: Remove 'spam' alias from spamchannel command

### DIFF
--- a/modules/base/admin/module.py
+++ b/modules/base/admin/module.py
@@ -463,7 +463,7 @@ class Admin(commands.Cog):
 
     @commands.guild_only()
     @check.acl2(check.ACLevel.SUBMOD)
-    @commands.group(name="spamchannel", aliases=["spam"])
+    @commands.group(name="spamchannel")
     async def spamchannel_(self, ctx):
         """Manage bot spam channels."""
         await utils.discord.send_help(ctx)


### PR DESCRIPTION
This shorthand may be used by some other command, as it is quite common
word and possible functionality. It is being removed so we don't pollute
the command name pool.