### PR TITLE
Docs: Link to Devel&Prod pages in General

### DIFF
--- a/docs/general/index.rst
+++ b/docs/general/index.rst
@@ -3,6 +3,12 @@
 I'm new to Discord bots
 =======================
 
+.. note::
+
+	If you are a developer, the :ref:`devel` page may be more suitable for you.
+
+	If you want to deploy your bot instance, take a look at :ref:`docker` or :ref:`direct`.
+
 
 .. _general_download:
 


### PR DESCRIPTION
The General page may not be suitable for general everyday developers, as
they tend to start running commands as they see them. This is an attempt
to direct them to more appropriate page.