### PR TITLE
Add ISO 8601 as primary datetime parser

### DIFF
--- a/tests/pie/utils/test_time.py
+++ b/tests/pie/utils/test_time.py
@@ -2,48 +2,125 @@ from datetime import datetime, timedelta
 
 from pie import utils
 
-
-def test_time_seconds():
-    assert "0:32" == utils.time.format_seconds(32)
-    assert "12:34" == utils.time.format_seconds(12 * 60 + 34)
-    assert "1:23:45" == utils.time.format_seconds(3600 + 23 * 60 + 45)
-    assert "12 d, 13:14:15" == utils.time.format_seconds(
-        12 * 24 * 3600 + 13 * 3600 + 14 * 60 + 15
-    )
+import pytest
 
 
-def test_parse_datetime():
-    # test the relative time format (ignoring seconds and microseconds as they can't be input and just computation can make them differ a bit)
-    temp = datetime.now() + timedelta(weeks=2, days=3, hours=4, minutes=5)
-    assert temp.replace(second=0, microsecond=0) == utils.time.parse_datetime(
-        "2w3d4h5m"
-    ).replace(second=0, microsecond=0)
-    temp = datetime.now() + timedelta(hours=17, minutes=6)
-    assert temp.replace(second=0, microsecond=0) == utils.time.parse_datetime(
-        "17 hours, 6 minutes"
-    ).replace(second=0, microsecond=0)
-    temp = datetime.now() + timedelta(weeks=1, days=4, hours=7, minutes=17)
-    assert temp.replace(second=0, microsecond=0) == utils.time.parse_datetime(
-        "1w; 4 dny, 7 hodin | 17 minut"
-    ).replace(second=0, microsecond=0)
+@pytest.mark.parametrize(
+    "result,seconds",
+    [
+        ("0:32", 32),
+        ("12:34", 12 * 60 + 34),
+        ("1:23:45", 3600 + 23 * 60 + 45),
+        ("12 d, 13:14:15", 12 * 24 * 3600 + 13 * 3600 + 14 * 60 + 15),
+    ],
+)
+def test_time_seconds(result: str, seconds: int):
+    assert result == utils.time.format_seconds(seconds)
 
-    # test full date formats
-    full_datetime = datetime(2021, 12, 31, 23, 59, 58)
-    assert full_datetime == utils.time.parse_datetime("2021-12-31 23:59:58")
-    assert full_datetime == utils.time.parse_datetime("2021/12/31 23:59:58")
-    assert full_datetime == utils.time.parse_datetime("2021.12.31 23:59:58")
-    assert full_datetime == utils.time.parse_datetime("31.12.2021 23:59:58")
-    assert full_datetime == utils.time.parse_datetime("31-12-2021 23:59:58")
-    assert full_datetime == utils.time.parse_datetime("31/12/2021 23:59:58")
-    assert full_datetime == utils.time.parse_datetime("20211231 235958")
-    assert full_datetime == utils.time.parse_datetime("20211231235958")
 
-    # test time portion only
-    now = datetime.now().replace(minute=0, second=0, microsecond=0)
-    now_plus = now + timedelta(hours=2, minutes=20)
-    now_minus = now - timedelta(hours=2, minutes=20)
+@pytest.mark.parametrize(
+    "result,string",
+    [
+        (datetime(2022, 6, 8), "20220608"),
+        (datetime(2022, 6, 8), "2022-06-08"),
+        (datetime(2022, 6, 8, 12, 0), "2022-06-08 12"),
+        (datetime(2022, 6, 8, 12, 0), "2022-06-08 12:00"),
+        (datetime(2022, 6, 8, 12, 0), "2022-06-08 12:00:00"),
+    ],
+)
+def test_iso8601_datetime(result: datetime, string: str):
+    assert result == utils.time.parse_iso8601_datetime(string)
 
-    assert now_plus == utils.time.parse_datetime(f"{now_plus.hour}:{now_plus.minute}")
-    assert now_minus + timedelta(days=1) == utils.time.parse_datetime(
-        f"{now_minus.hour}:{now_minus.minute}"
-    )
+
+@pytest.mark.parametrize(
+    "string",
+    [
+        "12",
+        "12:00",
+        "4:32",
+    ],
+)
+def test_iso8601_datetime__negative(string: str):
+    with pytest.raises(ValueError):
+        utils.time.parse_iso8601_datetime(string)
+
+
+@pytest.mark.parametrize(
+    "delta,string",
+    [
+        (
+            timedelta(weeks=2, days=3, hours=4, minutes=5),
+            "2w3d4h5m",
+        ),
+        (
+            timedelta(hours=17, minutes=6),
+            "17 hours, 6 minutes",
+        ),
+        (
+            timedelta(weeks=1, days=4, hours=7, minutes=17),
+            "1w, 4 dny, 7 hodin | 17 minut",
+        ),
+    ],
+)
+def test_fuzzy_datetime__relative(delta: str, string: str):
+    expected = (datetime.now() + delta).replace(second=0, microsecond=0)
+
+    result = utils.time.parse_fuzzy_datetime(string)
+    result = result.replace(second=0, microsecond=0)
+
+    assert expected == result
+
+
+@pytest.mark.parametrize(
+    "string",
+    [
+        # day month year; long
+        "06.08.2022 13:14:15",
+        "06-08-2022 13:14:15",
+        "06/08/2022 13:14:15",
+        # day month year; short
+        "6.08.2022 13:14:15",
+        "6-08-2022 13:14:15",
+        "6/08/2022 13:14:15",
+        "06.8.2022 13:14:15",
+        "06-8-2022 13:14:15",
+        "06/8/2022 13:14:15",
+        # year day month; long
+        "2022-06-08 13:14:15",
+        "2022/06/08 13:14:15",
+        "2022.06.08 13:14:15",
+        # year day month; short
+        "2022-6-08 13:14:15",
+        "2022/6/08 13:14:15",
+        "2022.6.08 13:14:15",
+        "2022-06-8 13:14:15",
+        "2022/06/8 13:14:15",
+        "2022.06.8 13:14:15",
+        # long, no separators
+        "20220608 131415",
+        "20220608131415",
+    ],
+)
+def test_fuzzy_datetime__absolute(string: str):
+    """Test fuzzy date parsing.
+
+    Note that even when the year is specified first, day comes before the month.
+    """
+    expected = datetime(2022, 8, 6, 13, 14, 15)
+
+    assert expected == utils.time.parse_fuzzy_datetime(string)
+
+
+@pytest.mark.parametrize(
+    "hours,minutes,seconds,string",
+    [
+        (13, 14, 0, "13:14"),
+        (13, 14, 15, "13:14:15"),
+    ],
+)
+def test_fuzzy_datetime__time(hours: int, minutes: int, seconds: int, string: str):
+    relative_to = datetime(2022, 8, 6, 18, 20)
+    expected = datetime(2022, 8, 7, hours, minutes, seconds)
+
+    result = utils.time.parse_fuzzy_datetime(string, relative_to=relative_to)
+    assert expected == result


### PR DESCRIPTION
While fuzzy-matching dates is nice, it has a problem of being unable to understand machine-friendly strings like the ISO 8601.

YYYY-xx-yy could be both YYYY-mm-dd and YYYY-dd-mm, depending on if the day is <= 12 or not.

I also updated the tests so they are parametrized, and each of the checks is done as separate test.