### PR TITLE
pie: Enable colored tables

### DIFF
--- a/pie/utils/text.py
+++ b/pie/utils/text.py
@@ -79,7 +79,7 @@ def parse_bool(string: str) -> Optional[bool]:
 
 
 def create_table(
-    iterable: Iterable, header: Dict[str, str], *, limit: int = 1990, rich: bool = False
+    iterable: Iterable, header: Dict[str, str], *, limit: int = 1990, rich: bool = True
 ) -> List[str]:
     """Create table from any iterable.
 
@@ -111,15 +111,15 @@ def create_table(
 
         matrix.append(line)
 
+    P: str = ""
     H: str = ""
     A: str = ""
     R: str = ""
-    P: str = ""
     if rich:
+        P = "ansi\n"
         H = "\u001b[1;34m"  # bold blue
         A = "\u001b[36m"  # cyan
         R = "\u001b[0m"  # reset
-        P = "ansi\n"
 
     page: str = P
     for i, matrix_line in enumerate(matrix):
@@ -136,7 +136,11 @@ def create_table(
             line += matrix_line[column_no].ljust(column_width + 2)
 
         # End line
-        line = line.rstrip() + R + "\n"
+        line = line.rstrip()
+        if i % 2 == 0:
+            line += R + "\n"
+        else:
+            line += "\n"
 
         # Add line
         if len(page) + len(line) > limit:

--- a/tests/pie/utils/test_text.py
+++ b/tests/pie/utils/test_text.py
@@ -40,7 +40,7 @@ def test_text_create_table():
         "123456789  b\n"
         "3          abcdefghijk\n"
     )
-    table: str = utils.text.create_table(iterable, header)
+    table: str = utils.text.create_table(iterable, header, rich=False)
     assert [expected] == table
 
 
@@ -60,7 +60,7 @@ def test_text_create_table_noattr():
         "b": "str",
     }
     expected = "int  str\n" "1    a\n" "2\n" "3    c\n"
-    table: str = utils.text.create_table(iterable, header)
+    table: str = utils.text.create_table(iterable, header, rich=False)
     assert [expected] == table
 
 
@@ -80,5 +80,31 @@ def test_text_create_table_wrapped():
     }
     page_1 = "Integer  String\n" "1111     aaaa\n"
     page_2 = "2222     bbbb\n"
-    table: List[str] = utils.text.create_table(iterable, header, limit=32)
+    table: List[str] = utils.text.create_table(iterable, header, limit=32, rich=False)
     assert [page_1, page_2] == table
+
+
+def test_text_create_table_colors():
+    class Item:
+        a: int
+        b: str
+
+        def __init__(self, a, b):
+            self.a = a
+            self.b = b
+
+    iterable = [Item(1, "a"), Item(123456789, "b"), Item(3, "abcdefghijk")]
+    header = {
+        "a": "Integer",
+        "b": "String",
+    }
+    expected = (
+        "ansi\n"
+        "\x1b[1;34mInteger    String\x1b[0m\n"
+        "1          a\n"
+        "\x1b[36m123456789  b\x1b[0m\n"
+        "3          abcdefghijk\n"
+    )
+
+    table: str = utils.text.create_table(iterable, header)
+    assert [expected] == table


### PR DESCRIPTION
Since the new Android app has been released a few weeks ago, we can enable colored tables in the output. Support for it has been present for several months now.

The colors are not visible on Android yet, but control characters are not being displayed anymore. Most of the administration is usually done on desktop.

We may add support for custom colors in the future, configurable by the server administrators, to allow synchronization with role or server colors.

![desktop](https://user-images.githubusercontent.com/14353790/190493637-98f548bc-e060-40fc-8441-6469b6af180b.png)

![android](https://user-images.githubusercontent.com/14353790/190493857-316e9695-cdba-441a-89d2-cc1f3498ccb1.png)
