### PR TITLE
TZ as ARG in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,9 @@ ENV PYTHONUNBUFFERED 1
 RUN apt-get update && apt-get -y --no-install-recommends install \
     make>=4.3-4.1 automake>=1:1.16.3-2 gcc>=4:10.2.1-1 g++>=4:10.2.1-1 \
     tzdata>=2021a-1+deb11u1 git>=1:2.30.2-1
-
-ENV TZ=Europe/Prague
+    
+ARG TZ=Europe/Prague
+ENV TZ=${TZ}
 
 WORKDIR /pumpkin-py
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,10 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args: ["TZ=Europe/Prague"]
+    
     env_file: .env
+    
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
       - ./:/pumpkin-py/:z


### PR DESCRIPTION
The .env file supplies runtime environment variables.  Not build-time variables. This is my solution to allow TZ to become a build variable.

If you convert TZ into an ARG in the Dockerfile, add it to the docker-compose.yml.  

Using `docker-compose build --build-arg "TZ=America/Phoenix"` will set the TZ at build.   
Use `docker-compose up -d` to start and `docker-compose stop` to gracefully stop.  
As well as `docker-compose logs -f` to follow the logs.

This does not work with `docker-compose up --build`.  There is no `--build-arg` for the `up` command.
