### PR TITLE
pie: Force flush to stdout

### DIFF
--- a/pie/logger/__init__.py
+++ b/pie/logger/__init__.py
@@ -264,7 +264,7 @@ class AbstractLogger:
         )
 
         stdout: str = entry.format_to_console()
-        print(stdout)
+        print(stdout, flush=True)
 
         filename: str = f"log_{entry.timestamp.strftime('%Y-%m-%d')}.log"
         if not os.path.isdir("logs"):


### PR DESCRIPTION
We are printing log messages to stdout, along with saving them to a log file. That is not a problem when the code is run directly in a terminal, because they tend to display text immediately. However, when the stdout is captured by systemd service, it can be held for quite a long time (over ten minutes). By force-flushing the `print` statement we should get nearly instant output.