### PR TITLE
Add author ID to bookmarker embeded.

### DIFF
--- a/modules/base/base/module.py
+++ b/modules/base/base/module.py
@@ -598,6 +598,10 @@ class Base(commands.Cog):
             icon_url=message.author.display_avatar.replace(size=64).url,
         )
 
+        embed.add_field(
+            name=_(utx, "Author ID"),
+            value=message.author.id,
+        )
         timestamp = utils.time.format_datetime(message.created_at)
         embed.add_field(
             name=f"{timestamp} UTC",

--- a/modules/base/po/cs.popie
+++ b/modules/base/po/cs.popie
@@ -340,6 +340,9 @@ msgstr Emoji 📍 používám já pro označení připnutých zpráv, použij �
 msgid 🔖 Bookmark created
 msgstr 🔖 Záložka vytvořena
 
+msgid Author ID
+msgstr ID autora
+
 msgid [Server {guild}, channel #{channel}]({link})
 msgstr [Server {guild}, kanál #{channel}]({link})
 

--- a/modules/base/po/sk.popie
+++ b/modules/base/po/sk.popie
@@ -340,6 +340,9 @@ msgstr Emoji 📍 používam ja na označenie pripnutých správ, použi 📌.
 msgid 🔖 Bookmark created
 msgstr 🔖 Záložka vytvorená
 
+msgid Author ID
+msgstr ID autora
+
 msgid [Server {guild}, channel #{channel}]({link})
 msgstr [Server {guild}, kanál #{channel}]({link})
 


### PR DESCRIPTION
Hi, this is enhancement for bookmarker embeded. This can be useful when some user using it a lot. So the search will be easier when finding message from specific author. Now it's hard because it take only server or global user name which is easy to change so searching for specific user is hard.

I added it as first field after the content of bookmarked message.

- [X] black
- [X] flake8
- [X] pytest
- [X] popie
- [X] tested functionality locally