### PR TITLE
moved docker backup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ modules/*
 *.db
 *.db-journal
 
+# Backups
+backups/*
+
 # Docs
 docs/_build
 docs/build

--- a/default.docker.env
+++ b/default.docker.env
@@ -1,5 +1,5 @@
 DB_STRING=postgresql://postgres:postgres@db:5432/postgres
-DOCKER_DB_BACKUP_PATH=/var/opt/pumpkin-backups
+DOCKER_DB_BACKUP_PATH=./backups
 TOKEN=
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres

--- a/default.docker.env
+++ b/default.docker.env
@@ -6,5 +6,5 @@ POSTGRES_PASSWORD=postgres
 POSTGRES_HOST=db
 POSTGRES_PORT=5432
 POSTGRES_DB=postgres
-POSTGRES_EXTRA_OPTS=-Z9 --schema=public --blobs
-SCHEDULE=@every 3h00m00s
+POSTGRES_EXTRA_OPTS="-Z9 --schema=public --blobs"
+SCHEDULE="@every 3h00m00s"


### PR DESCRIPTION
Changed the default environment variable for docker backup to `./backups` to allow for more compatibility across platforms.

Added `backups/*` to `.gitignore`