### PR TITLE
Add support for slash / hybrid commands

### DIFF
--- a/modules/base/admin/module.py
+++ b/modules/base/admin/module.py
@@ -389,6 +389,7 @@ class Admin(commands.Cog):
     async def module_load(self, ctx, name: str):
         """Load module. Use format <repository>.<module>."""
         await self.bot.load_extension("modules." + name + ".module")
+        await self.bot.tree.sync()
         await ctx.send(_(ctx, "Module **{name}** has been loaded.").format(name=name))
         Module.add(name, enabled=True)
         await bot_log.info(ctx.author, ctx.channel, "Loaded " + name)
@@ -403,6 +404,7 @@ class Admin(commands.Cog):
             )
             return
         await self.bot.unload_extension("modules." + name + ".module")
+        await self.bot.tree.sync()
         await ctx.send(_(ctx, "Module **{name}** has been unloaded.").format(name=name))
         Module.add(name, enabled=False)
         await bot_log.info(ctx.author, ctx.channel, "Unloaded " + name)
@@ -412,6 +414,7 @@ class Admin(commands.Cog):
     async def module_reload(self, ctx, name: str):
         """Reload bot module. Use format <repository>.<module>."""
         await self.bot.reload_extension("modules." + name + ".module")
+        await self.bot.tree.sync()
         await ctx.send(_(ctx, "Module **{name}** has been reloaded.").format(name=name))
         await bot_log.info(ctx.author, ctx.channel, "Reloaded " + name)
 

--- a/modules/base/base/module.py
+++ b/modules/base/base/module.py
@@ -522,7 +522,8 @@ class Base(commands.Cog):
 
         if emoji == "📍" and not payload.member.bot:
             await utils.discord.send_dm(
-                payload.member, _(utx, "I'm using 📍 to mark the pinned message, use 📌.")
+                payload.member,
+                _(utx, "I'm using 📍 to mark the pinned message, use 📌."),
             )
             await utils.discord.remove_reaction(message, emoji, payload.member)
             return

--- a/modules/base/baseinfo/module.py
+++ b/modules/base/baseinfo/module.py
@@ -18,7 +18,7 @@ class BaseInfo(commands.Cog):
     #
 
     @check.acl2(check.ACLevel.EVERYONE)
-    @commands.command()
+    @commands.hybrid_command()
     async def ping(self, ctx):
         """Return latency information."""
         delay: str = "{:.2f}".format(self.bot.latency)

--- a/pie/acl/__init__.py
+++ b/pie/acl/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import inspect
 import re
-from typing import Callable, Set, Optional, TypeVar
+from typing import Callable, Optional, Set, TypeVar, Union
 
 import ring
 
@@ -97,60 +97,85 @@ def acl2(level: ACLevel) -> Callable[[T], T]:
             await ctx.reply(utils.text.sanitise(input, escape=False))
     """
 
-    def predicate(ctx: commands.Context) -> bool:
-        return acl2_function(ctx, level)
+    def predicate(action: Union[commands.Context, discord.Interaction]) -> bool:
+        if type(action) is commands.Context:
+            ctx: commands.Context = action
+            return acl2_function(
+                level=level,
+                bot=ctx.bot,
+                invoker=ctx.author,
+                command=ctx.command.qualified_name,
+                guild=ctx.guild,
+                channel=ctx.channel,
+            )
+
+        bot: Union[commands.Bot, commands.AutoShardedBot] = action.client
+        invoker: Union[discord.User, discord.Member] = action.user
+        guild: discord.Guild = action.guild
+        channel: discord.abc.Messageable = action.channel
+        command: str = action.command.qualified_name
+
+        return acl2_function(
+            level=level,
+            bot=bot,
+            invoker=invoker,
+            command=command,
+            guild=guild,
+            channel=channel,
+        )
 
     return commands.check(predicate)
 
 
 # TODO Make cachable as well?
 def acl2_function(
-    ctx: commands.Context, level: ACLevel, *, for_command: Optional[str] = None
+    level: ACLevel,
+    bot: Union[commands.Bot, commands.AutoShardedBot],
+    invoker: Union[discord.User, discord.Member],
+    command: str,
+    guild: discord.Guild = None,
+    channel: discord.abc.Messageable = None,
 ) -> bool:
     """Check function based on Access Control.
 
     Set `for_command` to perform the check for other command
     then the one being invoked.
     """
-    if for_command:
-        command = for_command
-    else:
-        command: str = ctx.command.qualified_name
     _acl_trace = lambda message: _trace(f"[{command}] {message}")  # noqa: E731
 
     # Allow invocations in DM.
     # Wrap the function in `@commands.guild_only()` to change this behavior.
-    if ctx.guild is None:
+    if guild is None:
         _acl_trace("Non-guild context is always allowed.")
         return True
 
-    member_level = map_member_to_ACLevel(bot=ctx.bot, member=ctx.author)
+    member_level = map_member_to_ACLevel(bot=bot, member=invoker)
     if member_level == ACLevel.BOT_OWNER:
         _acl_trace("Bot owner is always allowed.")
         return True
 
-    custom_level = ACDefault.get(ctx.guild.id, command)
+    custom_level = ACDefault.get(guild.id, command)
     if custom_level:
         level = custom_level.level
 
     _acl_trace(f"Required level '{level.name}'.")
 
-    uo = UserOverwrite.get(ctx.guild.id, ctx.author.id, command)
+    uo = UserOverwrite.get(guild.id, invoker.id, command)
     if uo is not None:
-        _acl_trace(f"User overwrite for '{ctx.author}' exists: '{uo.allow}'.")
+        _acl_trace(f"User overwrite for '{invoker}' exists: '{uo.allow}'.")
         if uo.allow:
             return True
         raise NegativeUserOverwrite()
 
-    co = ChannelOverwrite.get(ctx.guild.id, ctx.channel.id, command)
+    co = ChannelOverwrite.get(guild.id, channel.id, command)
     if co is not None:
-        _acl_trace(f"Channel overwrite for '#{ctx.channel.name}' exists: '{co.allow}'.")
+        _acl_trace(f"Channel overwrite for '#{channel.name}' exists: '{co.allow}'.")
         if co.allow:
             return True
-        raise NegativeChannelOverwrite(channel=ctx.channel)
+        raise NegativeChannelOverwrite(channel=channel)
 
-    for role in ctx.author.roles:
-        ro = RoleOverwrite.get(ctx.guild.id, role.id, command)
+    for role in invoker.roles:
+        ro = RoleOverwrite.get(guild.id, role.id, command)
         if ro is not None:
             _acl_trace(f"Role overwrite for '{role.name}' exists: '{ro.allow}'.")
             if ro.allow:
@@ -211,7 +236,14 @@ def can_invoke_command(
         return False
 
     try:
-        acl2_function(ctx, command_level, for_command=command)
+        acl2_function(
+            level=command_level,
+            bot=ctx.bot,
+            invoker=ctx.author,
+            command=command,
+            guild=ctx.guild,
+            channel=ctx.channel,
+        )
         return True
     except ACLFailure:
         return False

--- a/pie/acl/__init__.py
+++ b/pie/acl/__init__.py
@@ -138,8 +138,16 @@ def acl2_function(
 ) -> bool:
     """Check function based on Access Control.
 
-    Set `for_command` to perform the check for other command
-    then the one being invoked.
+    Args:
+        level: ACLevel of the command.
+        bot: Bot instance.
+        invoker: Invoker of the command.
+        command: Command qualified name.
+        guild: Guild the command was run at.
+        channel: Channel the command was run in.
+
+    Returns:
+        True if command can be run, False otherwise.
     """
     _acl_trace = lambda message: _trace(f"[{command}] {message}")  # noqa: E731
 

--- a/pie/help.py
+++ b/pie/help.py
@@ -62,7 +62,7 @@ class Help(commands.MinimalHelpCommand):
 
         This override changes the language from english to l10n version.
         """
-        if type(command) == commands.Group and len(command.all_commands) > 0:
+        if type(command) is commands.Group and len(command.all_commands) > 0:
             return _(
                 ctx, "Command **{name}** does not have subcommand **{subcommand}**."
             ).format(
@@ -158,7 +158,7 @@ class Help(commands.MinimalHelpCommand):
     async def order_subcommands(self, cmds: Sequence[commands.Command]):
         """Order commands: first groups, then finals."""
         cmds = await self.filter_commands(cmds, sort=self.sort_commands)
-        groups = [c for c in cmds if type(c) == commands.Group]
+        groups = [c for c in cmds if type(c) is commands.Group]
         finals = [c for c in cmds if c not in groups]
         return groups, finals
 

--- a/pie/i18n/database.py
+++ b/pie/i18n/database.py
@@ -28,7 +28,7 @@ class GuildLanguage(database.base):
         )
 
     def __eq__(self, obj) -> bool:
-        return type(self) == type(obj) and self.guild_id == obj.guild_id
+        return type(self) is type(obj) and self.guild_id == obj.guild_id
 
     def dump(self) -> Dict[str, Union[int, str]]:
         return {
@@ -101,7 +101,7 @@ class MemberLanguage(database.base):
 
     def __eq__(self, obj) -> bool:
         return (
-            type(self) == type(obj)
+            type(self) is type(obj)
             and self.guild_id == obj.guild_id
             and self.member_id == obj.member_id
         )

--- a/pie/utils/time.py
+++ b/pie/utils/time.py
@@ -87,7 +87,7 @@ def parse_fuzzy_datetime(
         r"(?!\s*$)(?:(?P<weeks>\d+)(?: )?(?:w)(?:\D)*)?(?:(?P<days>\d+)(?: )"
         r"?(?:d)(?:\D)*)?(?:(?P<hours>\d+)(?: )?(?:h)(?:\D)*)?(?:(?P<minutes>\d+)(?: )"
         r"?(?:m)(?:\D)*)?",
-        re.IGNORECASE
+        re.IGNORECASE,
     )
     result = re.fullmatch(regex, string)
     if result is not None:

--- a/pumpkin.py
+++ b/pumpkin.py
@@ -170,6 +170,8 @@ async def on_ready():
     status = "invisible" if config.status == "auto" else config.status
     await utils.discord.update_presence(bot, status=status)
 
+    await bot.tree.sync()
+
     if already_loaded:
         await bot_log.info(None, None, "Reconnected")
     else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 wheel
-discord.py==2.3.1
+discord.py==2.3.2
 GitPython>=3.1.27,<4.0.0
 psycopg2-binary>=2.9.3,<3.0.0
 requests>=2.27.1,<3.0.0


### PR DESCRIPTION
Changes made so far:

1. flake8 and black first to make the checks happy (as it would probably fail)
2. updated discord.py to newest version (as we are gonna work with Slash commands)
3. added support for Interaction check into ACL2
4. fixed synchronization of slash / hybrid commands (on bot start + on module manipulation)
5. Converted ping command to hybrid.

As I'm working with ACL2 checks, even though I've tested it, I'd anyway recommend other people to test it out, just to be on the safe side.