### PR TITLE
[Docker] Allow instance naming

### DIFF
--- a/default.docker.env
+++ b/default.docker.env
@@ -1,4 +1,5 @@
 TOKEN=
+INSTANCE_NAME=pumpkin
 DB_STRING=postgresql://postgres:postgres@db:5432/postgres
 BOT_EXTRA_PACKAGES=
 BOT_TIMEZONE=Europe/Prague

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.6"
 services:
   db:
     image: docker.io/postgres:13-alpine
-    container_name: pumpkin-db
+    container_name: ${INSTANCE_NAME}-db
     volumes:
       - postgres_data:/var/lib/postgresql/data/
     environment:
@@ -13,7 +13,7 @@ services:
     restart: unless-stopped
   backup:
     image: docker.io/prodrigestivill/postgres-backup-local:13-alpine
-    container_name: pumpkin-backup
+    container_name: ${INSTANCE_NAME}-backup
     restart: unless-stopped
     volumes:
       - ${BACKUP_PATH}:/backups/:z
@@ -29,7 +29,7 @@ services:
       - SCHEDULE=${BACKUP_SCHEDULE}
   bot:
     image: docker.io/czechbol/pumpkin-py:latest
-    container_name: pumpkin-bot
+    container_name: ${INSTANCE_NAME}-bot
     env_file: .env
     volumes:
       - ./:/pumpkin-py/:z


### PR DESCRIPTION
Previously the name of the folder was used, then the breaking change to current state happened (and all instances are forcefully named pumpkin-...).

This change brings a ballance into these two approaches and allows the users to name the instances.